### PR TITLE
Bugfix all caps words not matching lowercased words.

### DIFF
--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/domain/model/Word.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/domain/model/Word.kt
@@ -6,4 +6,9 @@ data class Word(private val word: String)
     fun word() = word
 
     override fun toString(): String = this.word()
+
+    override fun equals(other: Any?): Boolean = other is Word
+        && this.word().trim().lowercase() == other.word().trim().lowercase()
+
+    override fun hashCode(): Int = word.hashCode()
 }

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/core/domain/model/WordTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/core/domain/model/WordTests.kt
@@ -20,6 +20,23 @@ class WordTests
     }
 
     @Test
+    fun `When searching for a capitalized word in a list of lowercase words - expected word is found`()
+    {
+        // given
+        val words = listOf(
+            Word(word = "test"),
+            Word(word = "another"),
+            Word(word = "finally")
+        )
+
+        // when
+        val wordIsFound = words.contains(Word(word = "FINALLY"))
+
+        // then
+        assertTrue(wordIsFound)
+    }
+
+    @Test
     fun `When initialized with word - letters method returns expected list of characters`()
     {
         // given


### PR DESCRIPTION
**Summary of Changes**
- Update Word domain entity to ignore capitalization differences when comparing equality.

**Code Review:**
- [ ] QA Kickoff notes added to JIRA issue
- [x] Unit tests exist if required
- [x] Code formatting standards reviewed
- [x] Error handling implemented (exceptions caught and relevant error messages displayed)

**Merge**
- [x] PR is against the correct branch
- [ ] All tests pass
