### PR TITLE
19 ios stats feature is missing

### DIFF
--- a/androidApp/src/androidTest/java/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CompletedGameLocalDataSourceTests.kt
+++ b/androidApp/src/androidTest/java/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CompletedGameLocalDataSourceTests.kt
@@ -19,7 +19,6 @@ import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.ext.realmListOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.*
 import org.junit.runner.RunWith

--- a/androidApp/src/androidTest/java/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CompletedGameLocalDataSourceTests.kt
+++ b/androidApp/src/androidTest/java/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CompletedGameLocalDataSourceTests.kt
@@ -18,7 +18,9 @@ import com.megabreezy.breezybuilds_wordle.core.ui.SceneMock
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.ext.query
-import io.realm.kotlin.internal.platform.epochInSeconds
+import io.realm.kotlin.ext.realmListOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.*
 import org.junit.runner.RunWith
 
@@ -30,7 +32,7 @@ class CompletedGameLocalDataSourceTests
     private val mockGamesList = listOf(
         CompletedGame(
             answer = Answer(word = Word("TOAST"), playerGuessedCorrectly = true),
-            date = epochInSeconds(),
+            date = 1680315545,
             playerGuesses = listOf(
                 Guess(word = Word(word = "TASTE")),
                 Guess(word = Word(word = "TRITE")),
@@ -39,7 +41,7 @@ class CompletedGameLocalDataSourceTests
         ),
         CompletedGame(
             answer = Answer(word = Word("SLAPS"), playerGuessedCorrectly = false),
-            date = epochInSeconds(),
+            date = 1680325545,
             playerGuesses = listOf(
                 Guess(word = Word(word = "TEARS")),
                 Guess(word = Word(word = "TRITE")),
@@ -82,11 +84,14 @@ class CompletedGameLocalDataSourceTests
         {
             expectedCompletedGames.forEach()
             {
+                val guessesToSave = realmListOf<String>()
+                it.playerGuesses().forEach { guess -> guessesToSave.add("${guess.word()}") }
+
                 copyToRealm(
                     CachedCompletedGame().apply {
                         answer = it.answer()
                         date = it.date()
-                        playerGuesses = it.playerGuesses().map { "${it.word()}" }
+                        playerGuesses = guessesToSave
                         playerGuessedCorrectly = it.answer().playerGuessedCorrectly() ?: false
                         word = "${it.answer().word()}"
                     }
@@ -104,6 +109,7 @@ class CompletedGameLocalDataSourceTests
         val gamesList = composeTestRule.onNodeWithContentDescription("COLUMN").onChildren()
 
         // then
+        composeTestRule.onRoot(useUnmergedTree = true).printToLog("TAG")
         gamesList.assertCountEquals(expectedCompletedGames.count())
         expectedCompletedGames.forEachIndexed()
         { index, game ->
@@ -140,12 +146,14 @@ class CompletedGameLocalDataSourceTests
         composeTestRule.setContent()
         {
             localDataSource = CompletedGameLocalDataSource(realm = realm)
+            runBlocking { localDataSource.put(newCompletedGame = expectedCompletedGame) }
 
-            SceneMock.display { MockView.Component(localDataSource = localDataSource, newCompletedGame = expectedCompletedGame) }
+            SceneMock.display { MockView.Component(localDataSource = localDataSource) }
         }
-        val gamesList = composeTestRule.onAllNodesWithContentDescription("${expectedCompletedGame.date()}")
+        val gamesList = composeTestRule.onNodeWithContentDescription("COLUMN").onChildren()
 
         // then
+        composeTestRule.onRoot(useUnmergedTree = true).printToLog("TAG")
         gamesList.assertCountEquals(1)
         gamesList.onFirst().assertContentDescriptionEquals("${expectedCompletedGame.date()}")
         gamesList.onFirst().assertTextEquals("${expectedCompletedGame.answer().word()}")
@@ -160,13 +168,13 @@ class CompletedGameLocalDataSourceTests
         )
         {
             var completedGames by remember { mutableStateOf<List<CompletedGame>>(listOf()) }
-            var updatedCompletedGame by remember { mutableStateOf(CompletedGame(answer = Answer(Word(word = "")))) }
+            var updatedCompletedGames by remember { mutableStateOf<List<CompletedGame>>(listOf()) }
 
             LaunchedEffect(Unit)
             {
-                completedGames = localDataSource.getAll()
+                updatedCompletedGames = newCompletedGame?.let { listOf(localDataSource.put(newCompletedGame = it)) } ?: listOf()
 
-                newCompletedGame?.let { updatedCompletedGame = localDataSource.put(newCompletedGame = it) }
+                completedGames = localDataSource.getAll()
             }
 
             Column(modifier = Modifier.fillMaxSize().semantics { contentDescription = "COLUMN" })
@@ -178,14 +186,6 @@ class CompletedGameLocalDataSourceTests
                         modifier = Modifier.semantics { contentDescription = "${it.date()}" }
                     )
                 }
-            }
-
-            updatedCompletedGame?.let()
-            {
-                Text(
-                    text = "${it.answer().word()}",
-                    modifier = Modifier.semantics { contentDescription = "${it.date()}" }
-                )
             }
         }
     }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		9D3C4B0B29E1DE0200D365BA /* StatsModalContentStatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */; };
 		9D3C4B0D29E1DFD800D365BA /* StatsModalContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */; };
 		9D3C4B0F29E1EA4800D365BA /* StatsModalContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0E29E1EA4800D365BA /* StatsModalContentTests.swift */; };
+		9D3C4B1229E30FA000D365BA /* SceneNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1129E30FA000D365BA /* SceneNavigationHandlerTests.swift */; };
+		9D3C4B1529E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1429E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift */; };
+		9D3C4B1829E3137100D365BA /* SceneNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1729E3137100D365BA /* SceneNavigationHandler.swift */; };
 		9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD48296F9A0A00FA8FDE /* GameSceneHandlerTests.swift */; };
 		9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD4A296F9B2400FA8FDE /* GameSceneHandler.swift */; };
 		9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D64C1722974613E00305AF7 /* GameSceneKeyboardTests.swift */; };
@@ -84,6 +87,9 @@
 		9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContentStatTests.swift; sourceTree = "<group>"; };
 		9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContent.swift; sourceTree = "<group>"; };
 		9D3C4B0E29E1EA4800D365BA /* StatsModalContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContentTests.swift; sourceTree = "<group>"; };
+		9D3C4B1129E30FA000D365BA /* SceneNavigationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneNavigationHandlerTests.swift; sourceTree = "<group>"; };
+		9D3C4B1429E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationHandlerCommonMock.swift; sourceTree = "<group>"; };
+		9D3C4B1729E3137100D365BA /* SceneNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneNavigationHandler.swift; sourceTree = "<group>"; };
 		9D3DBD3C296F98D100FA8FDE /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		9D3DBD3D296F98D100FA8FDE /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		9D3DBD3E296F98D100FA8FDE /* Roboto-ThinItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-ThinItalic.ttf"; sourceTree = "<group>"; };
@@ -244,6 +250,31 @@
 			path = component;
 			sourceTree = "<group>";
 		};
+		9D3C4B1029E30F9100D365BA /* navigation */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B1329E30FA500D365BA /* mock */,
+				9D3C4B1129E30FA000D365BA /* SceneNavigationHandlerTests.swift */,
+			);
+			path = navigation;
+			sourceTree = "<group>";
+		};
+		9D3C4B1329E30FA500D365BA /* mock */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B1429E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift */,
+			);
+			path = mock;
+			sourceTree = "<group>";
+		};
+		9D3C4B1629E3135E00D365BA /* navigation */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B1729E3137100D365BA /* SceneNavigationHandler.swift */,
+			);
+			path = navigation;
+			sourceTree = "<group>";
+		};
 		9D6098552948B75C00F2D7C9 /* iosAppTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -294,8 +325,9 @@
 		9DC3B683296C350B00D90945 /* core */ = {
 			isa = PBXGroup;
 			children = (
-				9DC3B69B296C504E00D90945 /* ui */,
+				9D3C4B1629E3135E00D365BA /* navigation */,
 				9DC3B697296C422200D90945 /* presentation */,
+				9DC3B69B296C504E00D90945 /* ui */,
 				9DC3B684296C351700D90945 /* util */,
 			);
 			path = core;
@@ -349,8 +381,9 @@
 		9DC3B68C296C382900D90945 /* core */ = {
 			isa = PBXGroup;
 			children = (
-				9DC3B69E296C52B100D90945 /* ui */,
+				9D3C4B1029E30F9100D365BA /* navigation */,
 				9DC3B698296C423200D90945 /* presentation */,
+				9DC3B69E296C52B100D90945 /* ui */,
 				9DC3B68D296C382E00D90945 /* util */,
 			);
 			path = core;
@@ -625,6 +658,7 @@
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				9DC3B69D296C506000D90945 /* Color+UI.swift in Sources */,
 				9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */,
+				9D3C4B1829E3137100D365BA /* SceneNavigationHandler.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				9D756F9E2970460A005C7705 /* GameSceneBoard.swift in Sources */,
 				9DC3B693296C393400D90945 /* SceneDimensions.swift in Sources */,
@@ -642,6 +676,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D3C4B0B29E1DE0200D365BA /* StatsModalContentStatTests.swift in Sources */,
+				9D3C4B1529E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift in Sources */,
 				9D3C4B0F29E1EA4800D365BA /* StatsModalContentTests.swift in Sources */,
 				9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */,
 				9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */,
@@ -649,6 +684,7 @@
 				9D8C9C3C2969C46C00761DA2 /* GameSceneTests.swift in Sources */,
 				9DC3B6A0296C52C600D90945 /* ColorTests.swift in Sources */,
 				9D756F9C297043EB005C7705 /* GameSceneBoardTests.swift in Sources */,
+				9D3C4B1229E30FA000D365BA /* SceneNavigationHandlerTests.swift in Sources */,
 				9DC3B69A296C425400D90945 /* ContentViewTests.swift in Sources */,
 				9DC3B691296C384B00D90945 /* SceneDimensionsTests.swift in Sources */,
 				9D1D2ECD29781323003A491E /* GameSceneAnnouncementTests.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9D1D2ECF29781453003A491E /* GameSceneAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1D2ECE29781453003A491E /* GameSceneAnnouncement.swift */; };
 		9D3C4B0229E19DA000D365BA /* StatsGuessDistributionRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */; };
 		9D3C4B0729E19E8400D365BA /* StatsGuessDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */; };
+		9D3C4B0929E1CECB00D365BA /* StatsGuessDistributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */; };
 		9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD48296F9A0A00FA8FDE /* GameSceneHandlerTests.swift */; };
 		9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD4A296F9B2400FA8FDE /* GameSceneHandler.swift */; };
 		9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D64C1722974613E00305AF7 /* GameSceneKeyboardTests.swift */; };
@@ -76,6 +77,7 @@
 		9D1D2ECE29781453003A491E /* GameSceneAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameSceneAnnouncement.swift; sourceTree = "<group>"; };
 		9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistributionRowTests.swift; sourceTree = "<group>"; };
 		9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistribution.swift; sourceTree = "<group>"; };
+		9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistributionTests.swift; sourceTree = "<group>"; };
 		9D3DBD3C296F98D100FA8FDE /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		9D3DBD3D296F98D100FA8FDE /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		9D3DBD3E296F98D100FA8FDE /* Roboto-ThinItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-ThinItalic.ttf"; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */,
+				9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */,
 			);
 			path = component;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				9D1D2ECD29781323003A491E /* GameSceneAnnouncementTests.swift in Sources */,
 				9DC3B6A6296C558300D90945 /* GameSceneHeaderTests.swift in Sources */,
 				9D3C4B0229E19DA000D365BA /* StatsGuessDistributionRowTests.swift in Sources */,
+				9D3C4B0929E1CECB00D365BA /* StatsGuessDistributionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		9D3C4B0229E19DA000D365BA /* StatsGuessDistributionRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */; };
 		9D3C4B0729E19E8400D365BA /* StatsGuessDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */; };
 		9D3C4B0929E1CECB00D365BA /* StatsGuessDistributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */; };
+		9D3C4B0B29E1DE0200D365BA /* StatsModalContentStatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */; };
+		9D3C4B0D29E1DFD800D365BA /* StatsModalContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */; };
 		9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD48296F9A0A00FA8FDE /* GameSceneHandlerTests.swift */; };
 		9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD4A296F9B2400FA8FDE /* GameSceneHandler.swift */; };
 		9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D64C1722974613E00305AF7 /* GameSceneKeyboardTests.swift */; };
@@ -78,6 +80,8 @@
 		9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistributionRowTests.swift; sourceTree = "<group>"; };
 		9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistribution.swift; sourceTree = "<group>"; };
 		9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistributionTests.swift; sourceTree = "<group>"; };
+		9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContentStatTests.swift; sourceTree = "<group>"; };
+		9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContent.swift; sourceTree = "<group>"; };
 		9D3DBD3C296F98D100FA8FDE /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		9D3DBD3D296F98D100FA8FDE /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		9D3DBD3E296F98D100FA8FDE /* Roboto-ThinItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-ThinItalic.ttf"; sourceTree = "<group>"; };
@@ -207,6 +211,7 @@
 			children = (
 				9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */,
 				9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */,
+				9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */,
 			);
 			path = component;
 			sourceTree = "<group>";
@@ -231,6 +236,7 @@
 			isa = PBXGroup;
 			children = (
 				9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */,
+				9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */,
 			);
 			path = component;
 			sourceTree = "<group>";
@@ -619,6 +625,7 @@
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				9D756F9E2970460A005C7705 /* GameSceneBoard.swift in Sources */,
 				9DC3B693296C393400D90945 /* SceneDimensions.swift in Sources */,
+				9D3C4B0D29E1DFD800D365BA /* StatsModalContent.swift in Sources */,
 				9DC3B68B296C370200D90945 /* AppDelegate.swift in Sources */,
 				9DC3B6A8296C565600D90945 /* GameSceneHeader.swift in Sources */,
 				9DC3B686296C352300D90945 /* Sizer.swift in Sources */,
@@ -631,6 +638,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D3C4B0B29E1DE0200D365BA /* StatsModalContentStatTests.swift in Sources */,
 				9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */,
 				9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */,
 				9DC3B696296C3BBD00D90945 /* XCTestCase+SceneDimensions.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		9D3C4B0929E1CECB00D365BA /* StatsGuessDistributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */; };
 		9D3C4B0B29E1DE0200D365BA /* StatsModalContentStatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */; };
 		9D3C4B0D29E1DFD800D365BA /* StatsModalContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */; };
+		9D3C4B0F29E1EA4800D365BA /* StatsModalContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0E29E1EA4800D365BA /* StatsModalContentTests.swift */; };
 		9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD48296F9A0A00FA8FDE /* GameSceneHandlerTests.swift */; };
 		9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD4A296F9B2400FA8FDE /* GameSceneHandler.swift */; };
 		9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D64C1722974613E00305AF7 /* GameSceneKeyboardTests.swift */; };
@@ -82,6 +83,7 @@
 		9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistributionTests.swift; sourceTree = "<group>"; };
 		9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContentStatTests.swift; sourceTree = "<group>"; };
 		9D3C4B0C29E1DFD800D365BA /* StatsModalContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContent.swift; sourceTree = "<group>"; };
+		9D3C4B0E29E1EA4800D365BA /* StatsModalContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsModalContentTests.swift; sourceTree = "<group>"; };
 		9D3DBD3C296F98D100FA8FDE /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		9D3DBD3D296F98D100FA8FDE /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		9D3DBD3E296F98D100FA8FDE /* Roboto-ThinItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-ThinItalic.ttf"; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */,
 				9D3C4B0829E1CECB00D365BA /* StatsGuessDistributionTests.swift */,
 				9D3C4B0A29E1DE0200D365BA /* StatsModalContentStatTests.swift */,
+				9D3C4B0E29E1EA4800D365BA /* StatsModalContentTests.swift */,
 			);
 			path = component;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D3C4B0B29E1DE0200D365BA /* StatsModalContentStatTests.swift in Sources */,
+				9D3C4B0F29E1EA4800D365BA /* StatsModalContentTests.swift in Sources */,
 				9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */,
 				9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */,
 				9DC3B696296C3BBD00D90945 /* XCTestCase+SceneDimensions.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		97938403D6D336375F950A15 /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17C0F794CA2046006F879E89 /* Pods_iosApp.framework */; };
 		9D1D2ECD29781323003A491E /* GameSceneAnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1D2ECC29781323003A491E /* GameSceneAnnouncementTests.swift */; };
 		9D1D2ECF29781453003A491E /* GameSceneAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1D2ECE29781453003A491E /* GameSceneAnnouncement.swift */; };
+		9D3C4B0229E19DA000D365BA /* StatsGuessDistributionRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */; };
+		9D3C4B0729E19E8400D365BA /* StatsGuessDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */; };
 		9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD48296F9A0A00FA8FDE /* GameSceneHandlerTests.swift */; };
 		9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD4A296F9B2400FA8FDE /* GameSceneHandler.swift */; };
 		9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D64C1722974613E00305AF7 /* GameSceneKeyboardTests.swift */; };
@@ -72,6 +74,8 @@
 		9903C30BBA4B2B467814F334 /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
 		9D1D2ECC29781323003A491E /* GameSceneAnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameSceneAnnouncementTests.swift; sourceTree = "<group>"; };
 		9D1D2ECE29781453003A491E /* GameSceneAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameSceneAnnouncement.swift; sourceTree = "<group>"; };
+		9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistributionRowTests.swift; sourceTree = "<group>"; };
+		9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGuessDistribution.swift; sourceTree = "<group>"; };
 		9D3DBD3C296F98D100FA8FDE /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		9D3DBD3D296F98D100FA8FDE /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		9D3DBD3E296F98D100FA8FDE /* Roboto-ThinItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-ThinItalic.ttf"; sourceTree = "<group>"; };
@@ -159,12 +163,13 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
-				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
+				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				9DC3B687296C368F00D90945 /* assets */,
 				9DC3B689296C36F100D90945 /* config */,
 				9DC3B683296C350B00D90945 /* core */,
 				9D8C9C2A2969C12500761DA2 /* feature_game */,
+				9D3C4B0329E19E6300D365BA /* feature_stats */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
 			);
 			path = iosApp;
@@ -179,12 +184,61 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		9D3C4AFE29E19D5700D365BA /* feature_stats */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4AFF29E19D6200D365BA /* presentation */,
+			);
+			path = feature_stats;
+			sourceTree = "<group>";
+		};
+		9D3C4AFF29E19D6200D365BA /* presentation */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B0029E19D6F00D365BA /* component */,
+			);
+			path = presentation;
+			sourceTree = "<group>";
+		};
+		9D3C4B0029E19D6F00D365BA /* component */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B0129E19DA000D365BA /* StatsGuessDistributionRowTests.swift */,
+			);
+			path = component;
+			sourceTree = "<group>";
+		};
+		9D3C4B0329E19E6300D365BA /* feature_stats */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B0429E19E6900D365BA /* presentation */,
+			);
+			path = feature_stats;
+			sourceTree = "<group>";
+		};
+		9D3C4B0429E19E6900D365BA /* presentation */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B0529E19E7100D365BA /* component */,
+			);
+			path = presentation;
+			sourceTree = "<group>";
+		};
+		9D3C4B0529E19E7100D365BA /* component */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B0629E19E8400D365BA /* StatsGuessDistribution.swift */,
+			);
+			path = component;
+			sourceTree = "<group>";
+		};
 		9D6098552948B75C00F2D7C9 /* iosAppTests */ = {
 			isa = PBXGroup;
 			children = (
-				9DC3B694296C3B7600D90945 /* extension */,
 				9DC3B68C296C382900D90945 /* core */,
+				9DC3B694296C3B7600D90945 /* extension */,
 				9D8C9C392969C44F00761DA2 /* feature_game */,
+				9D3C4AFE29E19D5700D365BA /* feature_stats */,
 			);
 			path = iosAppTests;
 			sourceTree = "<group>";
@@ -555,6 +609,7 @@
 				9DC3B6AC296C59F400D90945 /* View+Frame.swift in Sources */,
 				9D8C9C2E2969C15000761DA2 /* GameScene.swift in Sources */,
 				9DC3B6A2296C545300D90945 /* UIColor+RGBA.swift in Sources */,
+				9D3C4B0729E19E8400D365BA /* StatsGuessDistribution.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				9DC3B69D296C506000D90945 /* Color+UI.swift in Sources */,
 				9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */,
@@ -583,6 +638,7 @@
 				9DC3B691296C384B00D90945 /* SceneDimensionsTests.swift in Sources */,
 				9D1D2ECD29781323003A491E /* GameSceneAnnouncementTests.swift in Sources */,
 				9DC3B6A6296C558300D90945 /* GameSceneHeaderTests.swift in Sources */,
+				9D3C4B0229E19DA000D365BA /* StatsGuessDistributionRowTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		9D3C4B1229E30FA000D365BA /* SceneNavigationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1129E30FA000D365BA /* SceneNavigationHandlerTests.swift */; };
 		9D3C4B1529E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1429E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift */; };
 		9D3C4B1829E3137100D365BA /* SceneNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1729E3137100D365BA /* SceneNavigationHandler.swift */; };
+		9D3C4B1B29E3191700D365BA /* AppModalViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1A29E3191700D365BA /* AppModalViewHandlerTests.swift */; };
+		9D3C4B1E29E3193600D365BA /* AppModalCommonMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B1D29E3193600D365BA /* AppModalCommonMock.swift */; };
+		9D3C4B2129E31E9B00D365BA /* AppModalViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C4B2029E31E9B00D365BA /* AppModalViewHandler.swift */; };
 		9D3DBD49296F9A0A00FA8FDE /* GameSceneHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD48296F9A0A00FA8FDE /* GameSceneHandlerTests.swift */; };
 		9D3DBD4B296F9B2400FA8FDE /* GameSceneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DBD4A296F9B2400FA8FDE /* GameSceneHandler.swift */; };
 		9D64C1732974613E00305AF7 /* GameSceneKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D64C1722974613E00305AF7 /* GameSceneKeyboardTests.swift */; };
@@ -90,6 +93,9 @@
 		9D3C4B1129E30FA000D365BA /* SceneNavigationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneNavigationHandlerTests.swift; sourceTree = "<group>"; };
 		9D3C4B1429E30FBE00D365BA /* AppNavigationHandlerCommonMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationHandlerCommonMock.swift; sourceTree = "<group>"; };
 		9D3C4B1729E3137100D365BA /* SceneNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneNavigationHandler.swift; sourceTree = "<group>"; };
+		9D3C4B1A29E3191700D365BA /* AppModalViewHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModalViewHandlerTests.swift; sourceTree = "<group>"; };
+		9D3C4B1D29E3193600D365BA /* AppModalCommonMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModalCommonMock.swift; sourceTree = "<group>"; };
+		9D3C4B2029E31E9B00D365BA /* AppModalViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModalViewHandler.swift; sourceTree = "<group>"; };
 		9D3DBD3C296F98D100FA8FDE /* Roboto-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Medium.ttf"; sourceTree = "<group>"; };
 		9D3DBD3D296F98D100FA8FDE /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		9D3DBD3E296F98D100FA8FDE /* Roboto-ThinItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-ThinItalic.ttf"; sourceTree = "<group>"; };
@@ -275,6 +281,31 @@
 			path = navigation;
 			sourceTree = "<group>";
 		};
+		9D3C4B1929E318FE00D365BA /* app_modal */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B1C29E3192300D365BA /* mock */,
+				9D3C4B1A29E3191700D365BA /* AppModalViewHandlerTests.swift */,
+			);
+			path = app_modal;
+			sourceTree = "<group>";
+		};
+		9D3C4B1C29E3192300D365BA /* mock */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B1D29E3193600D365BA /* AppModalCommonMock.swift */,
+			);
+			path = mock;
+			sourceTree = "<group>";
+		};
+		9D3C4B1F29E31E9100D365BA /* app_modal */ = {
+			isa = PBXGroup;
+			children = (
+				9D3C4B2029E31E9B00D365BA /* AppModalViewHandler.swift */,
+			);
+			path = app_modal;
+			sourceTree = "<group>";
+		};
 		9D6098552948B75C00F2D7C9 /* iosAppTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -424,6 +455,7 @@
 		9DC3B69B296C504E00D90945 /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				9D3C4B1F29E31E9100D365BA /* app_modal */,
 				9DC3B6A9296C59D900D90945 /* view */,
 				9DC3B69C296C506000D90945 /* Color+UI.swift */,
 				9DC3B6A1296C545300D90945 /* UIColor+RGBA.swift */,
@@ -435,6 +467,7 @@
 			isa = PBXGroup;
 			children = (
 				9DC3B69F296C52C600D90945 /* ColorTests.swift */,
+				9D3C4B1929E318FE00D365BA /* app_modal */,
 			);
 			path = ui;
 			sourceTree = "<group>";
@@ -666,6 +699,7 @@
 				9DC3B68B296C370200D90945 /* AppDelegate.swift in Sources */,
 				9DC3B6A8296C565600D90945 /* GameSceneHeader.swift in Sources */,
 				9DC3B686296C352300D90945 /* Sizer.swift in Sources */,
+				9D3C4B2129E31E9B00D365BA /* AppModalViewHandler.swift in Sources */,
 				9D64C1772974688B00305AF7 /* GameSceneKeyboard.swift in Sources */,
 				9D1D2ECF29781453003A491E /* GameSceneAnnouncement.swift in Sources */,
 			);
@@ -686,8 +720,10 @@
 				9D756F9C297043EB005C7705 /* GameSceneBoardTests.swift in Sources */,
 				9D3C4B1229E30FA000D365BA /* SceneNavigationHandlerTests.swift in Sources */,
 				9DC3B69A296C425400D90945 /* ContentViewTests.swift in Sources */,
+				9D3C4B1B29E3191700D365BA /* AppModalViewHandlerTests.swift in Sources */,
 				9DC3B691296C384B00D90945 /* SceneDimensionsTests.swift in Sources */,
 				9D1D2ECD29781323003A491E /* GameSceneAnnouncementTests.swift in Sources */,
+				9D3C4B1E29E3193600D365BA /* AppModalCommonMock.swift in Sources */,
 				9DC3B6A6296C558300D90945 /* GameSceneHeaderTests.swift in Sources */,
 				9D3C4B0229E19DA000D365BA /* StatsGuessDistributionRowTests.swift in Sources */,
 				9D3C4B0929E1CECB00D365BA /* StatsGuessDistributionTests.swift in Sources */,

--- a/iosApp/iosApp/assets/Assets.xcassets/colors/color.background.colorset/Contents.json
+++ b/iosApp/iosApp/assets/Assets.xcassets/colors/color.background.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.706",
-          "green" : "0.706",
-          "red" : "0.706"
+          "blue" : "180",
+          "green" : "180",
+          "red" : "180"
         }
       },
       "idiom" : "universal"

--- a/iosApp/iosApp/core/navigation/SceneNavigationHandler.swift
+++ b/iosApp/iosApp/core/navigation/SceneNavigationHandler.swift
@@ -33,6 +33,6 @@ class SceneNavigationHandler: SceneNavigationHandleable
     func navigate(route: AppRoute, direction: NavigationDirection)
     {
         print("Navigating to \(route)")
-        iOSNavigator?.navigate(route.name)
+        Task { await MainActor.run {iOSNavigator?.navigate(route.name) } }
     }
 }

--- a/iosApp/iosApp/core/navigation/SceneNavigationHandler.swift
+++ b/iosApp/iosApp/core/navigation/SceneNavigationHandler.swift
@@ -12,7 +12,7 @@ import shared
 
 class SceneNavigationHandler: SceneNavigationHandleable
 {
-    @EnvironmentObject var iOSNavigator: Navigator
+    var iOSNavigator: Navigator?
     
     static let shared: SceneNavigationHandler = SceneNavigationHandler()
     
@@ -24,11 +24,15 @@ class SceneNavigationHandler: SceneNavigationHandleable
         self.appNavigator = appNavigator ?? NavHelper().appNavigator()
     }
     
-    func setUp() { appNavigator.setSceneNavigator(newSceneNavigator: self) }
+    func setUp(navigator: Navigator? = nil)
+    {
+        self.iOSNavigator = navigator
+        appNavigator.setSceneNavigator(newSceneNavigator: self)
+    }
     
     func navigate(route: AppRoute, direction: NavigationDirection)
     {
         print("Navigating to \(route)")
-        iOSNavigator.navigate(route.name)
+        iOSNavigator?.navigate(route.name)
     }
 }

--- a/iosApp/iosApp/core/navigation/SceneNavigationHandler.swift
+++ b/iosApp/iosApp/core/navigation/SceneNavigationHandler.swift
@@ -1,0 +1,34 @@
+//
+//  SceneNavigationHandler.swift
+//  iosApp
+//
+//  Created by Bradley Phillips on 4/9/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import SwiftUIRouter
+import shared
+
+class SceneNavigationHandler: SceneNavigationHandleable
+{
+    @EnvironmentObject var iOSNavigator: Navigator
+    
+    static let shared: SceneNavigationHandler = SceneNavigationHandler()
+    
+    var appNavigator: AppNavigationHandleable!
+    
+    
+    init(appNavigator: AppNavigationHandleable? = nil)
+    {
+        self.appNavigator = appNavigator ?? NavHelper().appNavigator()
+    }
+    
+    func setUp() { appNavigator.setSceneNavigator(newSceneNavigator: self) }
+    
+    func navigate(route: AppRoute, direction: NavigationDirection)
+    {
+        print("Navigating to \(route)")
+        iOSNavigator.navigate(route.name)
+    }
+}

--- a/iosApp/iosApp/core/presentation/ContentView.swift
+++ b/iosApp/iosApp/core/presentation/ContentView.swift
@@ -5,6 +5,7 @@ import shared
 struct ContentView: View
 {
     @ObservedObject private var sizer = Sizer.shared
+    @ObservedObject private var appModalHandler = AppModalViewHandler.shared
     @EnvironmentObject private var navigator: Navigator
     
     @StateObject private var sceneDimensions = SceneDimensions.shared
@@ -14,6 +15,7 @@ struct ContentView: View
         ZStack
         {
             SizerView()
+            
             SwitchRoutes
             {
                 Route(AppRoute.game.name)
@@ -26,8 +28,22 @@ struct ContentView: View
                 }
             }
             .transition(.opacity)
+            
+            if (appModalHandler.appModalIsShowing)
+            {
+                ZStack(alignment: .center)
+                {
+                    Color.clear
+                    
+                    appModalHandler.modalContent()
+                }
+            }
         }
-        .onAppear() { SceneNavigationHandler.shared.setUp() }
+        .onAppear()
+        {
+            SceneNavigationHandler.shared.setUp(navigator: navigator)
+            appModalHandler.setUp()
+        }
         .environmentObject(sceneDimensions)
         .onReceive(sizer.$content)
         { contentSize in

--- a/iosApp/iosApp/core/presentation/ContentView.swift
+++ b/iosApp/iosApp/core/presentation/ContentView.swift
@@ -28,7 +28,8 @@ struct ContentView: View
         { contentSize in
             sceneDimensions.setDimensions(
                 width: sizer.scaled(w: sizer.idealSize.width).width,
-                height: sizer.scaled(h: sizer.idealSize.height).height
+                height: sizer.scaled(h: sizer.idealSize.height).height,
+                screenSize: CGSize(width: contentSize.width, height: contentSize.height)
             )
         }
         .animation(.easeInOut, value: navigator.path)

--- a/iosApp/iosApp/core/presentation/ContentView.swift
+++ b/iosApp/iosApp/core/presentation/ContentView.swift
@@ -16,6 +16,10 @@ struct ContentView: View
             SizerView()
             SwitchRoutes
             {
+                Route(AppRoute.game.name)
+                {
+                    GameScene()
+                }
                 Route
                 {
                     GameScene()
@@ -23,6 +27,7 @@ struct ContentView: View
             }
             .transition(.opacity)
         }
+        .onAppear() { SceneNavigationHandler.shared.setUp() }
         .environmentObject(sceneDimensions)
         .onReceive(sizer.$content)
         { contentSize in

--- a/iosApp/iosApp/core/presentation/ContentView.swift
+++ b/iosApp/iosApp/core/presentation/ContentView.swift
@@ -26,7 +26,10 @@ struct ContentView: View
         .environmentObject(sceneDimensions)
         .onReceive(sizer.$content)
         { contentSize in
-            sceneDimensions.setDimensions(width: contentSize.width, height: contentSize.height)
+            sceneDimensions.setDimensions(
+                width: sizer.scaled(w: sizer.idealSize.width).width,
+                height: sizer.scaled(h: sizer.idealSize.height).height
+            )
         }
         .animation(.easeInOut, value: navigator.path)
 	}

--- a/iosApp/iosApp/core/presentation/ContentView.swift
+++ b/iosApp/iosApp/core/presentation/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View
             {
                 ZStack(alignment: .center)
                 {
-                    Color.clear
+                    Color.black.opacity(0.8)
                     
                     appModalHandler.modalContent()
                 }

--- a/iosApp/iosApp/core/ui/app_modal/AppModalViewHandler.swift
+++ b/iosApp/iosApp/core/ui/app_modal/AppModalViewHandler.swift
@@ -1,0 +1,58 @@
+//
+//  AppModalViewHandler.swift
+//  iosApp
+//
+//  Created by Bradley Phillips on 4/9/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import shared
+
+class AppModalViewHandler: ObservableObject, AppModalViewHandleable
+{
+    var appModalIsShowing = false
+    {
+        willSet { Task { await MainActor.run { objectWillChange.send() } } }
+    }
+    
+    var appModal: AppModalRepresentable!
+    
+    init(appModal: AppModalRepresentable? = nil)
+    {
+        self.appModal = appModal ?? AppModalHelper().appModal()
+    }
+    
+    func setUp() { appModal.setHandler(newHandler: self) }
+    
+    func onModalShouldHide(animationDuration: Int64)
+    {
+        appModalIsShowing = false
+    }
+    
+    func onModalShouldShow(animationDuration: Int64)
+    {
+        appModalIsShowing = true
+    }
+    
+    func modalContent() -> some View
+    {
+        ZStack
+        {
+            if let content = appModal.content() as? StatsModal
+            {
+                StatsModalContent(
+                    stats: [],
+                    guessDistribution: StatsGuessDistribution(
+                        title: "",
+                        rows: []
+                    ),
+                    playAgainButton: StatsModalContent.PlayAgainButton(
+                        label: "",
+                        tapped: { }
+                    )
+                )
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/core/ui/app_modal/AppModalViewHandler.swift
+++ b/iosApp/iosApp/core/ui/app_modal/AppModalViewHandler.swift
@@ -47,7 +47,7 @@ class AppModalViewHandler: ObservableObject, AppModalViewHandleable
                     stats: content.stats().map {
                         StatsModalContent.Stat(
                             headline: $0.headline(),
-                            description: $0.description()
+                            description: $0.description_()
                         )
                     },
                     guessDistribution: StatsGuessDistribution(

--- a/iosApp/iosApp/core/ui/app_modal/AppModalViewHandler.swift
+++ b/iosApp/iosApp/core/ui/app_modal/AppModalViewHandler.swift
@@ -11,6 +11,8 @@ import shared
 
 class AppModalViewHandler: ObservableObject, AppModalViewHandleable
 {
+    static let shared: AppModalViewHandler = AppModalViewHandler()
+    
     var appModalIsShowing = false
     {
         willSet { Task { await MainActor.run { objectWillChange.send() } } }
@@ -42,14 +44,25 @@ class AppModalViewHandler: ObservableObject, AppModalViewHandleable
             if let content = appModal.content() as? StatsModal
             {
                 StatsModalContent(
-                    stats: [],
+                    stats: content.stats().map {
+                        StatsModalContent.Stat(
+                            headline: $0.headline(),
+                            description: $0.description()
+                        )
+                    },
                     guessDistribution: StatsGuessDistribution(
-                        title: "",
-                        rows: []
+                        title: content.guessDistribution().title(),
+                        rows: content.guessDistribution().rows().map
+                        {
+                            StatsGuessDistribution.Row(
+                                round: "\($0.round())",
+                                correctGuessCount: "\($0.correctGuessesCount())"
+                            )
+                        }
                     ),
                     playAgainButton: StatsModalContent.PlayAgainButton(
-                        label: "",
-                        tapped: { }
+                        label: content.playAgainButton()?.label() ?? "",
+                        tapped: { content.playAgainButton()?.click() { _ in } }
                     )
                 )
             }

--- a/iosApp/iosApp/core/util/SceneDimensions.swift
+++ b/iosApp/iosApp/core/util/SceneDimensions.swift
@@ -16,13 +16,15 @@ class SceneDimensions: ObservableObject
     
     var width: CGFloat = 0
     var height: CGFloat = 0
+    var screenSize: CGSize = .zero
     
-    func setDimensions(width: CGFloat, height: CGFloat)
+    func setDimensions(width: CGFloat, height: CGFloat, screenSize: CGSize = .zero)
     {
         if (self.width != width && self.height != height)
         {
             self.width = width
             self.height = height
+            self.screenSize = screenSize
             
             dimensionsHaveReset = true
         }

--- a/iosApp/iosApp/feature_game/presentation/GameSceneHandler.swift
+++ b/iosApp/iosApp/feature_game/presentation/GameSceneHandler.swift
@@ -29,7 +29,7 @@ class GameSceneHandler: ObservableObject
     
     func setUp()
     {
-        if activeView == .EMPTY { viewModel.setUp(handler: self) { _ in self.getGameBoard() } }
+        viewModel.setUp(handler: self) { _ in self.getGameBoard() }
     }
     
     private func getGameBoard()

--- a/iosApp/iosApp/feature_game/presentation/component/GameSceneKeyboard.swift
+++ b/iosApp/iosApp/feature_game/presentation/component/GameSceneKeyboard.swift
@@ -98,7 +98,7 @@ extension GameSceneKeyboard
                     }
                 }
                 .frame(
-                    width: sceneDimensions.width * (keyWidth / idealFrameWidth()),
+                    width: sceneDimensions.screenSize.width * (keyWidth / idealFrameWidth()),
                     height: sceneDimensions.height * (56.0 / idealFrameHeight())
                 )
                 .cornerRadius(sceneDimensions.width * (4 / idealFrameWidth()))

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
@@ -1,0 +1,40 @@
+//
+//  StatsGuessDistribution.swift
+//  iosApp
+//
+//  Created by Bradley Phillips on 4/8/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+
+struct StatsGuessDistribution: View
+{
+    @EnvironmentObject private var dimensions: SceneDimensions
+    
+    var body: some View
+    {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+extension StatsGuessDistribution
+{
+    struct Row: View
+    {
+        @EnvironmentObject private var dimensions: SceneDimensions
+        
+        var round: String
+        
+        var body: some View
+        {
+            HStack(spacing: dimensions.width * (5 / idealFrameWidth()))
+            {
+                Text(round)
+                    .font(Font.custom("Roboto-Regular", size: dimensions.height * (20 / idealFrameHeight())))
+                    .multilineTextAlignment(.trailing)
+            }
+            .foregroundColor(.ui.onSurface)
+        }
+    }
+}

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
@@ -18,7 +18,7 @@ struct StatsGuessDistribution: View, Identifiable, Equatable
     
     var body: some View
     {
-        VStack(spacing: dimensions.height * (5 / idealFrameHeight()))
+        VStack(alignment: .leading, spacing: dimensions.height * (5 / idealFrameHeight()))
         {
             Text(title)
                 .font(Font.custom("Roboto-Black", size: dimensions.height * (20 / idealFrameHeight())))
@@ -28,6 +28,7 @@ struct StatsGuessDistribution: View, Identifiable, Equatable
             
             ForEach(rows, id: \.id) { $0 }
         }
+        .frame(maxWidth: .infinity)
         .padding(.bottom, dimensions.height * (40 / idealFrameHeight()))
     }
     

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
@@ -8,10 +8,11 @@
 
 import SwiftUI
 
-struct StatsGuessDistribution: View
+struct StatsGuessDistribution: View, Identifiable, Equatable
 {
     @EnvironmentObject private var dimensions: SceneDimensions
     
+    internal var id: String = UUID().uuidString
     var title: String
     var rows: [StatsGuessDistribution.Row]
     
@@ -28,6 +29,11 @@ struct StatsGuessDistribution: View
             ForEach(rows, id: \.id) { $0 }
         }
         .padding(.bottom, dimensions.height * (40 / idealFrameHeight()))
+    }
+    
+    static func == (lhs: StatsGuessDistribution, rhs: StatsGuessDistribution) -> Bool
+    {
+        lhs.title == rhs.title && lhs.rows == rhs.rows
     }
 }
 

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
@@ -25,14 +25,22 @@ extension StatsGuessDistribution
         @EnvironmentObject private var dimensions: SceneDimensions
         
         var round: String
+        var correctGuessCount: String
         
         var body: some View
         {
-            HStack(spacing: dimensions.width * (5 / idealFrameWidth()))
+            HStack( alignment: .center, spacing: dimensions.width * (5 / idealFrameWidth()))
             {
                 Text(round)
                     .font(Font.custom("Roboto-Regular", size: dimensions.height * (20 / idealFrameHeight())))
                     .multilineTextAlignment(.trailing)
+                
+                Text(correctGuessCount)
+                    .font(Font.custom("Roboto-Regular", size: dimensions.height * (20 / idealFrameHeight())))
+                    .multilineTextAlignment(.trailing)
+                    .padding(.horizontal, dimensions.width * (5 / idealFrameWidth()))
+                    .background(Color.ui.error)
+                    
             }
             .foregroundColor(.ui.onSurface)
         }

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsGuessDistribution.swift
@@ -12,18 +12,32 @@ struct StatsGuessDistribution: View
 {
     @EnvironmentObject private var dimensions: SceneDimensions
     
+    var title: String
+    var rows: [StatsGuessDistribution.Row]
+    
     var body: some View
     {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(spacing: dimensions.height * (5 / idealFrameHeight()))
+        {
+            Text(title)
+                .font(Font.custom("Roboto-Black", size: dimensions.height * (20 / idealFrameHeight())))
+                .multilineTextAlignment(.center)
+                .foregroundColor(Color.ui.onSurface)
+                .padding(.bottom, dimensions.height * (20 / idealFrameHeight()))
+            
+            ForEach(rows, id: \.id) { $0 }
+        }
+        .padding(.bottom, dimensions.height * (40 / idealFrameHeight()))
     }
 }
 
 extension StatsGuessDistribution
 {
-    struct Row: View
+    struct Row: View, Identifiable, Equatable
     {
         @EnvironmentObject private var dimensions: SceneDimensions
         
+        private(set) var id: String = UUID().uuidString
         var round: String
         var correctGuessCount: String
         
@@ -38,11 +52,17 @@ extension StatsGuessDistribution
                 Text(correctGuessCount)
                     .font(Font.custom("Roboto-Regular", size: dimensions.height * (20 / idealFrameHeight())))
                     .multilineTextAlignment(.trailing)
+                    .lineSpacing(dimensions.height * (25 / idealFrameHeight()))
                     .padding(.horizontal, dimensions.width * (5 / idealFrameWidth()))
                     .background(Color.ui.error)
                     
             }
             .foregroundColor(.ui.onSurface)
+        }
+        
+        static func == (lhs: StatsGuessDistribution.Row, rhs: StatsGuessDistribution.Row) -> Bool
+        {
+            lhs.round == rhs.round && lhs.correctGuessCount == rhs.correctGuessCount
         }
     }
 }

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
@@ -27,9 +27,8 @@ struct StatsModalContent: View
                     size: dimensions.height * (20 / idealFrameHeight())
                 ))
                 .foregroundColor(.ui.onSurface)
-                .padding(.top, dimensions.height * (40 / idealFrameHeight()))
             
-            HStack(spacing: dimensions.width * (5 / idealFrameWidth()))
+            HStack(alignment: .top, spacing: dimensions.width * (5 / idealFrameWidth()))
             {
                 ForEach(stats, id: \.id) { $0 }
             }
@@ -41,6 +40,7 @@ struct StatsModalContent: View
         }
         .frame(width: dimensions.width * (315.0 / idealFrameWidth()))
         .padding(.horizontal, dimensions.width * (20.0 / idealFrameWidth()))
+        .padding(.vertical, dimensions.height * (40 / idealFrameHeight()))
         .cornerRadius(dimensions.height * (8 / idealFrameHeight()))
         .background(Color.ui.surface)
     }
@@ -78,6 +78,7 @@ extension StatsModalContent
                     .foregroundColor(.ui.onSurface)
             }
             .padding(.bottom, dimensions.height * (15 / idealFrameHeight()))
+            .frame(maxWidth: .infinity)
         }
         
         static func == (lhs: StatsModalContent.Stat, rhs: StatsModalContent.Stat) -> Bool
@@ -108,13 +109,13 @@ extension StatsModalContent
                     ))
                     .multilineTextAlignment(.center)
                     .foregroundColor(.ui.surface)
+                    .frame(
+                        width: dimensions.width * (275 / idealFrameWidth()),
+                        height: dimensions.height * (50 / idealFrameHeight())
+                    )
+                    .background(Color.ui.secondary)
+                    .cornerRadius(dimensions.width * (4 / idealFrameWidth()))
             }
-            .frame(
-                width: dimensions.width * (375 / idealFrameWidth()),
-                height: dimensions.height * (50 / idealFrameHeight())
-            )
-            .background(Color.ui.secondary)
-            .cornerRadius(dimensions.width * (4 / idealFrameWidth()))
         }
         
         static func == (lhs: StatsModalContent.PlayAgainButton, rhs: StatsModalContent.PlayAgainButton) -> Bool

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
@@ -1,0 +1,50 @@
+//
+//  StatsModalCotent.swift
+//  iosApp
+//
+//  Created by Bradley Phillips on 4/8/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+
+struct StatsModalContent: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+extension StatsModalContent
+{
+    struct Stat: View
+    {
+        @EnvironmentObject private var dimensions: SceneDimensions
+        
+        var headline: String
+        var description: String
+        
+        var body: some View
+        {
+            VStack
+            {
+                Text(headline)
+                    .font(Font.custom(
+                        "Roboto-Regular",
+                        size: dimensions.height * (40 / idealFrameHeight())
+                    ))
+                    .lineSpacing(dimensions.height * (47 / idealFrameHeight()))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.ui.onSurface)
+                
+                Text(description)
+                    .font(Font.custom(
+                        "Roboto-Regular",
+                        size: dimensions.height * (14 / idealFrameHeight())
+                    ))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.ui.onSurface)
+            }
+            .padding(.bottom, dimensions.height * (15 / idealFrameHeight()))
+        }
+    }
+}

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
@@ -8,18 +8,50 @@
 
 import SwiftUI
 
-struct StatsModalContent: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+struct StatsModalContent: View
+{
+    @EnvironmentObject private var dimensions: SceneDimensions
+    
+    var stats: [StatsModalContent.Stat]
+    var guessDistribution: StatsGuessDistribution
+    var playAgainButton: StatsModalContent.PlayAgainButton
+    
+    var body: some View
+    {
+        VStack
+        {
+            Text("STATISTICS")
+                .font(Font.custom(
+                    "Roboto-Black",
+                    size: dimensions.height * (20 / idealFrameHeight())
+                ))
+                .foregroundColor(.ui.onSurface)
+                .padding(.top, dimensions.height * (40 / idealFrameHeight()))
+            
+            HStack(spacing: dimensions.width * (5 / idealFrameWidth()))
+            {
+                ForEach(stats, id: \.id) { $0 }
+            }
+            .padding(.bottom, dimensions.height * (15 / idealFrameHeight()))
+            
+            guessDistribution
+            
+            playAgainButton
+        }
+        .frame(width: dimensions.width * (315.0 / idealFrameWidth()))
+        .padding(.horizontal, dimensions.width * (20.0 / idealFrameWidth()))
+        .cornerRadius(dimensions.height * (8 / idealFrameHeight()))
+        .background(Color.ui.surface)
     }
 }
 
 extension StatsModalContent
 {
-    struct Stat: View
+    struct Stat: View, Identifiable, Equatable
     {
         @EnvironmentObject private var dimensions: SceneDimensions
         
+        internal var id: String = UUID().uuidString
         var headline: String
         var description: String
         
@@ -45,6 +77,48 @@ extension StatsModalContent
                     .foregroundColor(.ui.onSurface)
             }
             .padding(.bottom, dimensions.height * (15 / idealFrameHeight()))
+        }
+        
+        static func == (lhs: StatsModalContent.Stat, rhs: StatsModalContent.Stat) -> Bool
+        {
+            lhs.headline == rhs.headline && lhs.description == rhs.description
+        }
+    }
+}
+
+extension StatsModalContent
+{
+    struct PlayAgainButton: View, Identifiable, Equatable
+    {
+        @EnvironmentObject private var dimensions: SceneDimensions
+        
+        internal var id: String = UUID().uuidString
+        var label: String
+        var tapped: () -> Void
+        
+        var body: some View
+        {
+            Button(action: tapped)
+            {
+                Text(label)
+                    .font(Font.custom(
+                        "Roboto-Black",
+                        size: dimensions.height * (14 / idealFrameHeight())
+                    ))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.ui.surface)
+            }
+            .frame(
+                width: dimensions.width * (375 / idealFrameWidth()),
+                height: dimensions.height * (50 / idealFrameHeight())
+            )
+            .background(Color.ui.secondary)
+            .cornerRadius(dimensions.width * (4 / idealFrameWidth()))
+        }
+        
+        static func == (lhs: StatsModalContent.PlayAgainButton, rhs: StatsModalContent.PlayAgainButton) -> Bool
+        {
+            lhs.label == rhs.label
         }
     }
 }

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
@@ -41,8 +41,15 @@ struct StatsModalContent: View
         .frame(width: dimensions.width * (315.0 / idealFrameWidth()))
         .padding(.horizontal, dimensions.width * (20.0 / idealFrameWidth()))
         .padding(.vertical, dimensions.height * (40 / idealFrameHeight()))
-        .cornerRadius(dimensions.height * (8 / idealFrameHeight()))
-        .background(Color.ui.surface)
+        .background(
+            RoundedRectangle(cornerRadius: dimensions.height * (8 / idealFrameHeight()))
+                .stroke(Color.ui.error, lineWidth: dimensions.height * (1 / idealFrameHeight()))
+                .background(
+                    RoundedRectangle(cornerRadius: dimensions.height * (8 / idealFrameHeight()))
+                        .fill(Color.ui.surface)
+                )
+        )
+        .shadow(color: Color.black.opacity(0.25), radius: dimensions.height * (10 / idealFrameHeight()))
     }
 }
 

--- a/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
+++ b/iosApp/iosApp/feature_stats/presentation/component/StatsModalContent.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import shared
 
 struct StatsModalContent: View
 {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -13,6 +13,7 @@ struct iOSApp: App
             Router
             {
                 ContentView()
+                
             }
         }
 	}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -13,7 +13,6 @@ struct iOSApp: App
             Router
             {
                 ContentView()
-                
             }
         }
 	}

--- a/iosApp/iosAppTests/core/navigation/SceneNavigationHandlerTests.swift
+++ b/iosApp/iosAppTests/core/navigation/SceneNavigationHandlerTests.swift
@@ -1,0 +1,27 @@
+//
+//  SceneNavigationHandlerTests.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/9/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import XCTest
+@testable import iosApp
+
+final class SceneNavigationHandlerTests: XCTestCase
+{
+    func test_when_setUp_invoked__AppNavigationHandleable_setHandler_method_is_invoked_passing_in_self()
+    {
+        // given
+        let mockNavigator = AppNavigationHandlerCommonMock()
+        let sut = SceneNavigationHandler(appNavigator: mockNavigator)
+        
+        // when
+        sut.setUp()
+        
+        // then
+        XCTAssertNotNil(mockNavigator.sceneNavigator)
+    }
+}

--- a/iosApp/iosAppTests/core/navigation/mock/AppNavigationHandlerCommonMock.swift
+++ b/iosApp/iosAppTests/core/navigation/mock/AppNavigationHandlerCommonMock.swift
@@ -1,0 +1,34 @@
+//
+//  AppNavigationHandlerCommonMock.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/9/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import Foundation
+import shared
+
+class AppNavigationHandlerCommonMock: AppNavigationHandleable
+{
+    var currentRouteToReturn: AppRoute? = nil
+    var navigateMethodPassedInRoute: AppRoute? = nil
+    var navigateMethodPassedInDirection: NavigationDirection? = nil
+    var popBackMethodPassedInNumberOfScreens: Int32? = nil
+    var sceneNavigator: SceneNavigationHandleable? = nil
+    
+    func currentRoute() -> AppRoute? { currentRouteToReturn }
+    
+    func navigate(route: AppRoute, direction: NavigationDirection)
+    {
+        navigateMethodPassedInRoute = route
+        navigateMethodPassedInDirection = direction
+    }
+    
+    func popBack(numberOfScreens: Int32) { popBackMethodPassedInNumberOfScreens = numberOfScreens }
+    
+    func setSceneNavigator(newSceneNavigator: SceneNavigationHandleable)
+    {
+        self.sceneNavigator = newSceneNavigator
+    }
+}

--- a/iosApp/iosAppTests/core/ui/app_modal/AppModalViewHandlerTests.swift
+++ b/iosApp/iosAppTests/core/ui/app_modal/AppModalViewHandlerTests.swift
@@ -1,0 +1,131 @@
+//
+//  AppModalViewHandlerTests.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/9/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import iosApp
+@testable import shared
+
+final class AppModalViewHandlerTests: XCTestCase
+{
+    func test_when_setUp_invoked__AppModal__setHandler_method_is_invoked_passing_in_self()
+    {
+        // given
+        let mockModal = AppModalCommonMock()
+        let sut = AppModalViewHandler(appModal: mockModal)
+        
+        // when
+        sut.setUp()
+        
+        // then
+        XCTAssertNotNil(mockModal.setHandlerMethodPassedInNewHandler)
+    }
+    
+    func test_when_onModalShouldShow_invoked__expected_view_is_displayed() throws
+    {
+        //given
+        let mockModal = AppModalCommonMock()
+        let expectedModalContent = MockSharedModalHelper().mockStatsModal()
+        let sut = AppModalViewHandler(appModal: mockModal)
+        mockModal.contentToReturn = expectedModalContent
+        let mockView = MockView(handler: sut)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: mockView.environmentObject(SceneDimensions()))
+        mockModal.handler()?.onModalShouldShow(animationDuration: 0)
+        let displayedMockView = try mockView.inspect().find(MockView.self)
+        
+        // then
+        XCTAssertNoThrow(try displayedMockView.zStack().find(StatsModalContent.self))
+    }
+    
+    func test_when_onModalShouldHide_invoked__expected_view_is_not_displayed() throws
+    {
+        //given
+        let mockModal = AppModalCommonMock()
+        let expectedModalContent = MockSharedModalHelper().mockStatsModal()
+        let sut = AppModalViewHandler(appModal: mockModal)
+        mockModal.contentToReturn = expectedModalContent
+        let mockView = MockView(handler: sut)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: mockView.environmentObject(SceneDimensions()))
+        mockModal.handler()?.onModalShouldShow(animationDuration: 0)
+        mockModal.handler()?.onModalShouldHide(animationDuration: 0)
+        let displayedMockView = try mockView.inspect().find(MockView.self)
+        
+        // then
+        XCTAssertThrowsError(try displayedMockView.zStack().find(StatsModalContent.self))
+    }
+    
+    struct MockView: View
+    {
+        @ObservedObject var handler: AppModalViewHandler
+        
+        var body: some View
+        {
+            ZStack
+            {
+                if (handler.appModalIsShowing) { handler.modalContent() }
+            }
+            .onAppear { handler.setUp() }
+        }
+    }
+    
+    class MockSharedModalHelper
+    {
+        var closeButtonClicked = false
+        var playAgainButtonClicked = false
+        
+        var statsToReturn: [Stat] = [
+            Stat(headline: "10", description: "Something"),
+            Stat(headline: "20", description: "Cool!")
+        ]
+        var guessDistributionToReturn: GuessDistribution = GuessDistribution(
+            title: "Guess Distribution",
+            rows: [
+                GuessDistribution.Row(round: 1, correctGuessesCount: 2),
+                GuessDistribution.Row(round: 2, correctGuessesCount: 3)
+            ]
+        )
+        
+        func mockStatsModal() -> StatsModal
+        {
+            var closeButton = Button { _ in self.closeButtonClicked = true }
+            var playAgainButton = Button { _ in self.playAgainButtonClicked = true }
+            
+            return StatsModal(
+                closeButton: closeButton,
+                stats: statsToReturn,
+                guessDistribution: guessDistributionToReturn,
+                playAgainButton: playAgainButton
+            )
+        }
+        
+        class Button: ButtonRepresentable
+        {
+            var mockResourceId: String?
+            var mockLabel: String?
+            var onClick: (Error?) -> Void
+            
+            init(mockResourceId: String? = nil, mockLabel: String? = nil, onClick: @escaping (Error?) -> Void)
+            {
+                self.mockResourceId = mockResourceId
+                self.mockLabel = mockLabel
+                self.onClick = onClick
+            }
+            
+            func click(completionHandler: @escaping (Error?) -> Void) { onClick(nil) }
+            func imageResourceId() -> String? { mockResourceId }
+            func label() -> String? { mockLabel }
+        }
+    }
+}

--- a/iosApp/iosAppTests/core/ui/app_modal/AppModalViewHandlerTests.swift
+++ b/iosApp/iosAppTests/core/ui/app_modal/AppModalViewHandlerTests.swift
@@ -38,7 +38,7 @@ final class AppModalViewHandlerTests: XCTestCase
         let mockView = MockView(handler: sut)
         let expectedModalStats = expectedModalContent.stats().map
         { commonStat in
-            StatsModalContent.Stat(headline: commonStat.headline(), description: commonStat.description())
+            StatsModalContent.Stat(headline: commonStat.headline(), description: commonStat.description_())
         }
         let expectedGuessDistribution = StatsGuessDistribution(
             title: expectedModalContent.guessDistribution().title(),

--- a/iosApp/iosAppTests/core/ui/app_modal/mock/AppModalCommonMock.swift
+++ b/iosApp/iosAppTests/core/ui/app_modal/mock/AppModalCommonMock.swift
@@ -1,0 +1,33 @@
+//
+//  AppModalCommonMock.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/9/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import Foundation
+import shared
+
+class AppModalCommonMock: AppModalRepresentable
+{
+    var contentToReturn: AppModalContentRepresentable? = nil
+    var viewHandler: AppModalViewHandleable? = nil
+    var setContentMethodPassedInNewContent: AppModalContentRepresentable? = nil
+    var setHandlerMethodPassedInNewHandler: AppModalViewHandleable?  = nil
+    
+    func content() -> AppModalContentRepresentable? { contentToReturn }
+    
+    func handler() -> AppModalViewHandleable? { viewHandler }
+    
+    func setContent(newContent: AppModalContentRepresentable?)
+    {
+        self.setContentMethodPassedInNewContent = newContent
+    }
+    
+    func setHandler(newHandler: AppModalViewHandleable?)
+    {
+        viewHandler = newHandler
+        self.setHandlerMethodPassedInNewHandler = newHandler
+    }
+}

--- a/iosApp/iosAppTests/extension/XCTestCase+SceneDimensions.swift
+++ b/iosApp/iosAppTests/extension/XCTestCase+SceneDimensions.swift
@@ -14,4 +14,6 @@ extension XCTestCase
     func idealFrame() -> (width: CGFloat, height: CGFloat) { (390, 844) }
     
     func mockFrame() -> (width: CGFloat, height: CGFloat) { (300, 700) }
+    
+    func mockScreen() -> (width: CGFloat, height: CGFloat) { (400, 700) }
 }

--- a/iosApp/iosAppTests/feature_game/presentation/component/GameSceneKeyboardTests.swift
+++ b/iosApp/iosAppTests/feature_game/presentation/component/GameSceneKeyboardTests.swift
@@ -32,14 +32,18 @@ final class GameSceneKeyboardTests: XCTestCase
     {
         // given
         let expectedCornerRadius = mockFrame().width * (4.0 / idealFrame().width)
-        let expectedFrameWidth = mockFrame().width * (33.0 / idealFrame().width)
+        let expectedFrameWidth = mockScreen().width * (33.0 / idealFrame().width)
         let expectedFrameHeight = mockFrame().height * (56.0 / idealFrame().height)
         let sut = GameSceneKeyboard.Key()
         
         // when
         defer { ViewHosting.expel() }
         ViewHosting.host(view: sut.environmentObject(dimensions))
-        dimensions.setDimensions(width: mockFrame().width, height: mockFrame().height)
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
         
         // then
         XCTAssertEqual(expectedCornerRadius, try sut.inspect().button().labelView().zStack().cornerRadius())
@@ -68,14 +72,18 @@ final class GameSceneKeyboardTests: XCTestCase
     func test_when_enter_key_appears__shape_matches_design_requirements()
     {
         // given
-        let expectedFrameWidth = mockFrame().width * (52.0 / idealFrame().width)
+        let expectedFrameWidth = mockScreen().width * (52.0 / idealFrame().width)
         let expectedFrameHeight = mockFrame().height * (56.0 / idealFrame().height)
         let sut = GameSceneKeyboard.Key(letters: "ENTER")
         
         // when
         defer { ViewHosting.expel() }
         ViewHosting.host(view: sut.environmentObject(dimensions))
-        dimensions.setDimensions(width: mockFrame().width, height: mockFrame().height)
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
         
         // then
         XCTAssertEqual(expectedFrameWidth, try sut.inspect().button().labelView().zStack().fixedWidth())
@@ -85,7 +93,7 @@ final class GameSceneKeyboardTests: XCTestCase
     func test_when_backspace_key_appears__shape_matches_design_requirements()
     {
         // given
-        let expectedFrameWidth = mockFrame().width * (52.0 / idealFrame().width)
+        let expectedFrameWidth = mockScreen().width * (52.0 / idealFrame().width)
         let expectedFrameHeight = mockFrame().height * (56.0 / idealFrame().height)
         let expectedImageSize = mockFrame().width * (23.0 / idealFrame().width)
         let sut = GameSceneKeyboard.Key(resourceId: "game_image_backspace")
@@ -94,7 +102,11 @@ final class GameSceneKeyboardTests: XCTestCase
         // when
         defer { ViewHosting.expel() }
         ViewHosting.host(view: sut.environmentObject(dimensions))
-        dimensions.setDimensions(width: mockFrame().width, height: mockFrame().height)
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
         
         // then
         XCTAssertEqual(expectedFrameWidth, try sut.inspect().button().labelView().zStack().fixedWidth())

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionRowTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionRowTests.swift
@@ -39,6 +39,7 @@ final class StatsGuessDistributionRowTests: XCTestCase
         
         // then
         XCTAssertEqual(mockFrame().width * (5 / idealFrame().width), try sut.inspect().hStack().spacing())
+        XCTAssertEqual(.center, try sut.inspect().hStack().alignment())
         XCTAssertNoThrow(try sut.inspect().hStack().text(0))
         XCTAssertEqual("1", try sut.inspect().hStack().text(0).string())
     }
@@ -67,27 +68,51 @@ final class StatsGuessDistributionRowTests: XCTestCase
         XCTAssertEqual(.trailing, try displayedRow.hStack().text(0).multilineTextAlignment())
     }
     
-    func test_when_view_appears_with_correctGuessCount__the_HStack_contains_an_HStack_at_index_1()
+    func test_when_view_appears_with_correctGuessCount__the_HStack_contains_a_Text_view_at_index_1()
     {
+        // given
+        let sut = StatsGuessDistribution.Row(mockCorrectGuessCount: "99")
         
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(SceneDimensions()))
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().hStack().text(1))
+        XCTAssertEqual("99", try sut.inspect().hStack().text(1).string())
     }
     
-    func test_when_view_appears_with_correctGuessCount__the_nested_HStack_contains_a_Text_view()
+    func test_when_view_appears_with_correctGuessCount__the_Text_view_matches_design_requirements() throws
     {
-        // dev note: should align content trailing (so the text stays right aligned within the grey bar)
-    }
-    
-    func test_when_view_appears_with_correctGuessCount__the_Text_view_matches_design_requirements()
-    {
-        // text align: trailing, color onSurface, font = roboto regular, 20, padding left + right = 5
+        // given
+        let expectedFont = Font.custom(
+            "Roboto-Regular",
+            size: mockFrame().height * (20 / idealFrame().height)
+        )
+        let expectedHorizontalPadding = mockFrame().width * (5 / idealFrame().width)
+        let sut = StatsGuessDistribution.Row(mockCorrectGuessCount: "99")
+        let dimensions = SceneDimensions()
         
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(width: mockFrame().width, height: mockFrame().height)
+        let displayedRow = try sut.inspect().find(StatsGuessDistribution.Row.self)
+        let displayedTextAttributes = try displayedRow.hStack().text(1).attributes()
+        
+        // then
+        XCTAssertEqual(try expectedFont.name(), try displayedTextAttributes.font().name())
+        XCTAssertEqual(try expectedFont.size(), try displayedTextAttributes.font().size())
+        XCTAssertEqual(.trailing, try displayedRow.hStack().text(1).multilineTextAlignment())
+        XCTAssertEqual(expectedHorizontalPadding, try displayedRow.hStack().text(1).padding(.horizontal))
+        XCTAssertEqual(.ui.error, try displayedRow.hStack().text(1).background().color().value())
     }
 }
 
 extension StatsGuessDistribution.Row
 {
-    init(mockRound: String = "")
+    init(mockRound: String = "", mockCorrectGuessCount: String = "")
     {
-        self.init(round: mockRound)
+        self.init(round: mockRound, correctGuessCount: mockCorrectGuessCount)
     }
 }

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionRowTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionRowTests.swift
@@ -1,0 +1,93 @@
+//
+//  StatsGuessDistributionTests.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/8/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import iosApp
+
+final class StatsGuessDistributionRowTests: XCTestCase
+{
+    func test_when_view_appears__the_outermost_element_is_an_HStack()
+    {
+        // given
+        let sut = StatsGuessDistribution.Row()
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(SceneDimensions()))
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().hStack())
+    }
+    
+    func test_when_view_appears_with_round__the_HStack_contains_a_Text_view_matching_expected_round()
+    {
+        // given
+        let sut = StatsGuessDistribution.Row(mockRound: "1")
+        let dimensions = SceneDimensions()
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(width: mockFrame().width, height: mockFrame().height)
+        
+        // then
+        XCTAssertEqual(mockFrame().width * (5 / idealFrame().width), try sut.inspect().hStack().spacing())
+        XCTAssertNoThrow(try sut.inspect().hStack().text(0))
+        XCTAssertEqual("1", try sut.inspect().hStack().text(0).string())
+    }
+    
+    func test_when_view_appears_with_round__the_Text_view_matches_design_requirements() throws
+    {
+        // given
+        let expectedFont = Font.custom(
+            "Roboto-Regular",
+            size: mockFrame().height * (20 / idealFrame().height)
+        )
+        let sut = StatsGuessDistribution.Row(mockRound: "1")
+        let dimensions = SceneDimensions()
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(width: mockFrame().width, height: mockFrame().height)
+        let displayedRow = try sut.inspect().find(StatsGuessDistribution.Row.self)
+        let displayedTextAttributes = try displayedRow.hStack().text(0).attributes()
+        
+        // then
+        XCTAssertEqual(Color.ui.onSurface, try displayedRow.hStack().foregroundColor())
+        XCTAssertEqual(try expectedFont.name(), try displayedTextAttributes.font().name())
+        XCTAssertEqual(try expectedFont.size(), try displayedTextAttributes.font().size())
+        XCTAssertEqual(.trailing, try displayedRow.hStack().text(0).multilineTextAlignment())
+    }
+    
+    func test_when_view_appears_with_correctGuessCount__the_HStack_contains_an_HStack_at_index_1()
+    {
+        
+    }
+    
+    func test_when_view_appears_with_correctGuessCount__the_nested_HStack_contains_a_Text_view()
+    {
+        // dev note: should align content trailing (so the text stays right aligned within the grey bar)
+    }
+    
+    func test_when_view_appears_with_correctGuessCount__the_Text_view_matches_design_requirements()
+    {
+        // text align: trailing, color onSurface, font = roboto regular, 20, padding left + right = 5
+        
+    }
+}
+
+extension StatsGuessDistribution.Row
+{
+    init(mockRound: String = "")
+    {
+        self.init(round: mockRound)
+    }
+}

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionRowTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionRowTests.swift
@@ -89,6 +89,7 @@ final class StatsGuessDistributionRowTests: XCTestCase
             "Roboto-Regular",
             size: mockFrame().height * (20 / idealFrame().height)
         )
+        let expectedLineHeight = mockFrame().height * (25 / idealFrame().height)
         let expectedHorizontalPadding = mockFrame().width * (5 / idealFrame().width)
         let sut = StatsGuessDistribution.Row(mockCorrectGuessCount: "99")
         let dimensions = SceneDimensions()
@@ -103,6 +104,7 @@ final class StatsGuessDistributionRowTests: XCTestCase
         // then
         XCTAssertEqual(try expectedFont.name(), try displayedTextAttributes.font().name())
         XCTAssertEqual(try expectedFont.size(), try displayedTextAttributes.font().size())
+        XCTAssertEqual(expectedLineHeight, try displayedRow.hStack().text(1).lineSpacing())
         XCTAssertEqual(.trailing, try displayedRow.hStack().text(1).multilineTextAlignment())
         XCTAssertEqual(expectedHorizontalPadding, try displayedRow.hStack().text(1).padding(.horizontal))
         XCTAssertEqual(.ui.error, try displayedRow.hStack().text(1).background().color().value())

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionTests.swift
@@ -37,6 +37,8 @@ final class StatsGuessDistributionTests: XCTestCase
         XCTAssertNoThrow(try sut.inspect().vStack())
         XCTAssertEqual(expectedStackSpacing, try sut.inspect().vStack().spacing())
         XCTAssertEqual(expectedBottomPadding, try sut.inspect().vStack().padding(.bottom))
+        XCTAssertEqual(.leading, try sut.inspect().vStack().alignment())
+        XCTAssertEqual(.infinity, try sut.inspect().vStack().flexFrame().maxWidth)
     }
     
     func test_when_view_appears_with_title__a_Text_view_the_first_view_within_the_VStack()

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsGuessDistributionTests.swift
@@ -1,0 +1,112 @@
+//
+//  StatsGuessDistributionTests.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/8/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import iosApp
+
+final class StatsGuessDistributionTests: XCTestCase
+{
+    var dimensions: SceneDimensions!
+    
+    override func setUp() async throws { dimensions = SceneDimensions() }
+    
+    func test_when_view_appears__the_outermost_element_is_a_VStack()
+    {
+        // given
+        let expectedStackSpacing = mockFrame().height * (5 / idealFrame().height)
+        let expectedBottomPadding = mockFrame().height * (40 / idealFrame().height)
+        let sut = StatsGuessDistribution()
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().vStack())
+        XCTAssertEqual(expectedStackSpacing, try sut.inspect().vStack().spacing())
+        XCTAssertEqual(expectedBottomPadding, try sut.inspect().vStack().padding(.bottom))
+    }
+    
+    func test_when_view_appears_with_title__a_Text_view_the_first_view_within_the_VStack()
+    {
+        // given
+        let sut = StatsGuessDistribution(mockTitle: "Test Title")
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().vStack().text(0))
+        XCTAssertEqual("Test Title", try sut.inspect().vStack().text(0).string())
+    }
+    
+    func test_when_view_appears_with_title__the_Text_view_matches_design_requirements() throws
+    {
+        // given
+        let expectedFont = Font.custom(
+            "Roboto-Black",
+            size: mockFrame().height * (20 / idealFrame().height)
+        )
+        let expectedBottomPadding = mockFrame().height * (20 / idealFrame().height)
+        let sut = StatsGuessDistribution(mockTitle: "Test Title")
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        let displayedFont = try sut.inspect().vStack().text(0)
+        
+        // then
+        XCTAssertEqual(try expectedFont.name(), try displayedFont.attributes().font().name())
+        XCTAssertEqual(try expectedFont.size(), try displayedFont.attributes().font().size())
+        XCTAssertEqual(.center, try displayedFont.multilineTextAlignment())
+        XCTAssertEqual(.ui.onSurface, try displayedFont.attributes().foregroundColor())
+        XCTAssertEqual(expectedBottomPadding, try displayedFont.padding(.bottom))
+    }
+    
+    func test_when_view_appears_with_rows__expected_rows_are_displayed()
+    {
+        // given
+        let expectedRows = [
+            StatsGuessDistribution.Row(round: "1", correctGuessCount: "10"),
+            StatsGuessDistribution.Row(round: "12", correctGuessCount: "153")
+        ]
+        let sut = StatsGuessDistribution(mockRows: expectedRows)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        
+        // then
+        XCTAssertEqual(expectedRows.count, try sut.inspect().vStack().forEach(1).count)
+        try? expectedRows.enumerated().forEach()
+        { index, row in
+            XCTAssertEqual(row, try sut.inspect().vStack().forEach(1).view(StatsGuessDistribution.Row.self, index).actualView())
+        }
+    }
+}
+
+extension StatsGuessDistribution
+{
+    init(mockTitle: String = "", mockRows: [StatsGuessDistribution.Row] = [])
+    {
+        self.init(title: mockTitle, rows: mockRows)
+    }
+}

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentStatTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentStatTests.swift
@@ -36,6 +36,7 @@ final class StatsModalContentStatTests: XCTestCase
         // then
         XCTAssertNoThrow(try sut.inspect().vStack())
         XCTAssertEqual(expectedBottomPadding, try sut.inspect().vStack().padding(.bottom))
+        XCTAssertEqual(.infinity, try sut.inspect().vStack().flexFrame().maxWidth)
     }
     
     func test_when_view_appears_with_headline__the_first_element_inside_the_VStack_is_a_Text_view()

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentStatTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentStatTests.swift
@@ -1,0 +1,131 @@
+//
+//  StatsModalStatTests.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/8/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import iosApp
+
+final class StatsModalContentStatTests: XCTestCase
+{
+    var dimensions: SceneDimensions!
+    
+    override func setUp() async throws { dimensions = SceneDimensions() }
+
+    func test_when_view_appears__the_outermost_element_is_a_VStack()
+    {
+        // padding bottom: 15
+        // given
+        let sut = StatsModalContent.Stat()
+        let expectedBottomPadding = mockFrame().height * (15.0 / idealFrame().height)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().vStack())
+        XCTAssertEqual(expectedBottomPadding, try sut.inspect().vStack().padding(.bottom))
+    }
+    
+    func test_when_view_appears_with_headline__the_first_element_inside_the_VStack_is_a_Text_view()
+    {
+        // given
+        let sut = StatsModalContent.Stat(mockHeadline: "20")
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().vStack().text(0))
+        XCTAssertEqual("20", try sut.inspect().vStack().text(0).string())
+    }
+    
+    func test_when_view_appears_with_headline__the_Text_view_matches_design_requirements() throws
+    {
+        // given
+        let expectedFont = Font.custom(
+            "Roboto-Regular",
+            size: mockFrame().height * (40 / idealFrame().height)
+        )
+        let expectedLineSpacing = mockFrame().height * (47 / idealFrame().height)
+        let sut = StatsModalContent.Stat(mockHeadline: "20")
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        let displayedText = try sut.inspect().vStack().text(0)
+        
+        // then
+        XCTAssertEqual(try expectedFont.name(), try displayedText.attributes().font().name())
+        XCTAssertEqual(try expectedFont.size(), try displayedText.attributes().font().size())
+        XCTAssertEqual(expectedLineSpacing, try displayedText.lineSpacing())
+        XCTAssertEqual(.ui.onSurface, try displayedText.attributes().foregroundColor())
+        XCTAssertEqual(.center, try displayedText.multilineTextAlignment())
+    }
+    
+    func test_when_view_appears_with_description__the_second_element_inside_the_VStack_is_a_Text_view()
+    {
+        // given
+        let sut = StatsModalContent.Stat(mockDescription: "Max Streak")
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().vStack().text(1))
+        XCTAssertEqual("Max Streak", try sut.inspect().vStack().text(1).string())
+    }
+    
+    func test_when_view_appears_with_description__the_Text_view_matches_design_requirements() throws
+    {
+        // text-align: center, font: Roboto-Regular, size: 14
+        // given
+        let expectedFont = Font.custom(
+            "Roboto-Regular",
+            size: mockFrame().height * (14 / idealFrame().height)
+        )
+        let sut = StatsModalContent.Stat(mockDescription: "Win %")
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        let displayedText = try sut.inspect().vStack().text(1)
+        
+        // then
+        XCTAssertEqual(try expectedFont.name(), try displayedText.attributes().font().name())
+        XCTAssertEqual(try expectedFont.size(), try displayedText.attributes().font().size())
+        XCTAssertEqual(.ui.onSurface, try displayedText.attributes().foregroundColor())
+        XCTAssertEqual(.center, try displayedText.multilineTextAlignment())
+    }
+}
+
+extension StatsModalContent.Stat
+{
+    init(mockHeadline: String = "", mockDescription: String = "")
+    {
+        self.init(headline: mockHeadline, description: mockDescription)
+    }
+}

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentTests.swift
@@ -24,6 +24,7 @@ final class StatsModalContentTests: XCTestCase
         let expectedWidth = mockFrame().width * (315.0 / idealFrame().width)
         let expectedBoarderRadius = mockFrame().height * (8 / idealFrame().height)
         let expectedHorizontalPadding = mockFrame().width * (20 / idealFrame().width)
+        let expectedVerticalPadding = mockFrame().height * (40.0 / idealFrame().height)
         
         // when
         defer { ViewHosting.expel() }
@@ -39,13 +40,13 @@ final class StatsModalContentTests: XCTestCase
         XCTAssertEqual(expectedWidth, try sut.inspect().vStack().fixedWidth())
         XCTAssertEqual(expectedBoarderRadius, try sut.inspect().vStack().cornerRadius())
         XCTAssertEqual(expectedHorizontalPadding, try sut.inspect().vStack().padding(.horizontal))
+        XCTAssertEqual(expectedVerticalPadding, try sut.inspect().vStack().padding(.vertical))
         XCTAssertEqual(.ui.surface, try sut.inspect().vStack().background().color().value())
     }
     
     func test_when_view_appears__a_Text_view_matching_design_requirements_is_displayed_in_the_VStack_index_1() throws
     {
         // given
-        let expectedTopPadding = mockFrame().height * (40.0 / idealFrame().height)
         let expectedFont = Font.custom("Roboto-Black", size: mockFrame().height * (20 / idealFrame().height))
         let expectedText = "STATISTICS"
         let sut = StatsModalContent()
@@ -65,7 +66,6 @@ final class StatsModalContentTests: XCTestCase
         XCTAssertEqual(try expectedFont.name(), try displayedText.attributes().font().name())
         XCTAssertEqual(try expectedFont.size(), try displayedText.attributes().font().size())
         XCTAssertEqual(.ui.onSurface, try displayedText.attributes().foregroundColor())
-        XCTAssertEqual(expectedTopPadding, try sut.inspect().vStack().text(0).padding(.top))
     }
     
     func test_when_view_appears_with_stats__an_HStack_matching_design_requirements_is_displayed_in_the_VStack_at_index_1() throws
@@ -89,6 +89,7 @@ final class StatsModalContentTests: XCTestCase
         )
         
         // then
+        XCTAssertEqual(.top, try sut.inspect().vStack().hStack(1).alignment())
         XCTAssertEqual(expectedSpacing, try sut.inspect().vStack().hStack(1).spacing())
         XCTAssertEqual(expectedBottomPadding, try sut.inspect().vStack().hStack(1).padding(.bottom))
         XCTAssertEqual(expectedStats.count, try sut.inspect().vStack().hStack(1).forEach(0).count)
@@ -122,7 +123,7 @@ final class StatsModalContentTests: XCTestCase
         var tapDidInvoke = false
         let expectedPlayAgainButton = StatsModalContent.PlayAgainButton(mockLabel: "Test Button")
             { tapDidInvoke = true }
-        let expectedButtonWidth = mockFrame().width * (375 / idealFrame().width)
+        let expectedButtonWidth = mockFrame().width * (275 / idealFrame().width)
         let expectedButtonHeight = mockFrame().height * (50 / idealFrame().height)
         let expectedCornerRadius = mockFrame().width * (4 / idealFrame().width)
         let expectedButtonFont = Font.custom("Roboto-Black", size: mockFrame().height * (14 / idealFrame().height))
@@ -143,10 +144,10 @@ final class StatsModalContentTests: XCTestCase
         
         // then
         XCTAssertEqual(expectedPlayAgainButton, try displayedButton.actualView())
-        XCTAssertEqual(expectedButtonWidth, try displayedButton.button().fixedWidth())
-        XCTAssertEqual(expectedButtonHeight, try displayedButton.button().fixedHeight())
-        XCTAssertEqual(.ui.secondary, try displayedButton.button().background().color().value())
-        XCTAssertEqual(expectedCornerRadius, try displayedButton.button().cornerRadius())
+        XCTAssertEqual(expectedButtonWidth, try displayedButton.button().labelView().fixedWidth())
+        XCTAssertEqual(expectedButtonHeight, try displayedButton.button().labelView().fixedHeight())
+        XCTAssertEqual(.ui.secondary, try displayedButton.button().labelView().background().color().value())
+        XCTAssertEqual(expectedCornerRadius, try displayedButton.button().labelView().cornerRadius())
         XCTAssertEqual("Test Button", try displayedButton.button().labelView().text().string())
         XCTAssertEqual(.center, try displayedButton.button().labelView().text().multilineTextAlignment())
         XCTAssertEqual(.ui.surface, try displayedButton.button().labelView().text().attributes().foregroundColor())

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentTests.swift
@@ -1,0 +1,181 @@
+//
+//  StatsModalContentTests.swift
+//  iosAppTests
+//
+//  Created by Bradley Phillips on 4/8/23.
+//  Copyright © 2023 orgName. All rights reserved.
+//
+
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import iosApp
+
+final class StatsModalContentTests: XCTestCase
+{
+    var dimensions: SceneDimensions!
+    
+    override func setUp() async throws { dimensions = SceneDimensions() }
+
+    func test_when_view_appears__the_outermost_element_is_a_VStack()
+    {
+        // given
+        let sut = StatsModalContent()
+        let expectedWidth = mockFrame().width * (315.0 / idealFrame().width)
+        let expectedBoarderRadius = mockFrame().height * (8 / idealFrame().height)
+        let expectedHorizontalPadding = mockFrame().width * (20 / idealFrame().width)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        
+        // then
+        XCTAssertNoThrow(try sut.inspect().vStack())
+        XCTAssertEqual(expectedWidth, try sut.inspect().vStack().fixedWidth())
+        XCTAssertEqual(expectedBoarderRadius, try sut.inspect().vStack().cornerRadius())
+        XCTAssertEqual(expectedHorizontalPadding, try sut.inspect().vStack().padding(.horizontal))
+        XCTAssertEqual(.ui.surface, try sut.inspect().vStack().background().color().value())
+    }
+    
+    func test_when_view_appears__a_Text_view_matching_design_requirements_is_displayed_in_the_VStack_index_1() throws
+    {
+        // given
+        let expectedTopPadding = mockFrame().height * (40.0 / idealFrame().height)
+        let expectedFont = Font.custom("Roboto-Black", size: mockFrame().height * (20 / idealFrame().height))
+        let expectedText = "STATISTICS"
+        let sut = StatsModalContent()
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        let displayedText = try sut.inspect().vStack().text(0)
+        
+        // then
+        XCTAssertEqual(expectedText, try sut.inspect().vStack().text(0).string())
+        XCTAssertEqual(try expectedFont.name(), try displayedText.attributes().font().name())
+        XCTAssertEqual(try expectedFont.size(), try displayedText.attributes().font().size())
+        XCTAssertEqual(.ui.onSurface, try displayedText.attributes().foregroundColor())
+        XCTAssertEqual(expectedTopPadding, try sut.inspect().vStack().text(0).padding(.top))
+    }
+    
+    func test_when_view_appears_with_stats__an_HStack_matching_design_requirements_is_displayed_in_the_VStack_at_index_1() throws
+    {
+        // given
+        let expectedStats = [
+            StatsModalContent.Stat(mockHeadline: "90", mockDescription: "Yah!"),
+            StatsModalContent.Stat(mockHeadline: "??", mockDescription: "That's it")
+        ]
+        let expectedSpacing = mockFrame().width * (5 / idealFrame().width)
+        let expectedBottomPadding = mockFrame().height * (15 / idealFrame().height)
+        let sut = StatsModalContent(mockStats: expectedStats)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        
+        // then
+        XCTAssertEqual(expectedSpacing, try sut.inspect().vStack().hStack(1).spacing())
+        XCTAssertEqual(expectedBottomPadding, try sut.inspect().vStack().hStack(1).padding(.bottom))
+        XCTAssertEqual(expectedStats.count, try sut.inspect().vStack().hStack(1).forEach(0).count)
+        
+        try? expectedStats.enumerated().forEach()
+        { index, stat in
+            XCTAssertEqual(stat, try sut.inspect().vStack().hStack(1).forEach(0).view(StatsModalContent.Stat.self, index).actualView())
+        }
+    }
+    
+    func test_when_view_appears_with_guessDistribution__expected_view_is_displayed_in_the_VStack_at_index_2()
+    {
+        // given
+        let expectedGuessDistribution = StatsGuessDistribution(mockTitle: "My Distribution!")
+        let sut = StatsModalContent(mockGuessDistribution: expectedGuessDistribution)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        
+        // then
+        XCTAssertEqual(
+            expectedGuessDistribution,
+            try sut.inspect().vStack().view(StatsGuessDistribution.self, 2).actualView()
+        )
+    }
+    
+    func test_when_view_appears_with_playAgainButton__expected_view_is_displayed_in_the_VStack_at_index_3() throws
+    {
+        // given
+        var tapDidInvoke = false
+        let expectedPlayAgainButton = StatsModalContent.PlayAgainButton(mockLabel: "Test Button")
+            { tapDidInvoke = true }
+        let expectedButtonWidth = mockFrame().width * (375 / idealFrame().width)
+        let expectedButtonHeight = mockFrame().height * (50 / idealFrame().height)
+        let expectedCornerRadius = mockFrame().width * (4 / idealFrame().width)
+        let expectedButtonFont = Font.custom("Roboto-Black", size: mockFrame().height * (14 / idealFrame().height))
+        
+        // when
+        let sut = StatsModalContent(mockPlayAgainButton: expectedPlayAgainButton)
+        
+        // when
+        defer { ViewHosting.expel() }
+        ViewHosting.host(view: sut.environmentObject(dimensions))
+        dimensions.setDimensions(
+            width: mockFrame().width,
+            height: mockFrame().height,
+            screenSize: CGSize(width: mockScreen().width, height: mockScreen().height)
+        )
+        let displayedButton = try sut.inspect().vStack().view(StatsModalContent.PlayAgainButton.self, 3)
+        try displayedButton.button().tap()
+        
+        // then
+        XCTAssertEqual(expectedPlayAgainButton, try displayedButton.actualView())
+        XCTAssertEqual(expectedButtonWidth, try displayedButton.button().fixedWidth())
+        XCTAssertEqual(expectedButtonHeight, try displayedButton.button().fixedHeight())
+        XCTAssertEqual(.ui.secondary, try displayedButton.button().background().color().value())
+        XCTAssertEqual(expectedCornerRadius, try displayedButton.button().cornerRadius())
+        XCTAssertEqual("Test Button", try displayedButton.button().labelView().text().string())
+        XCTAssertEqual(.center, try displayedButton.button().labelView().text().multilineTextAlignment())
+        XCTAssertEqual(.ui.surface, try displayedButton.button().labelView().text().attributes().foregroundColor())
+        XCTAssertEqual(try expectedButtonFont.name(), try displayedButton.button().labelView().text().attributes().font().name())
+        XCTAssertEqual(try expectedButtonFont.size(), try displayedButton.button().labelView().text().attributes().font().size())
+        XCTAssertTrue(tapDidInvoke)
+    }
+}
+
+extension StatsModalContent
+{
+    init(
+        mockStats: [StatsModalContent.Stat] = [],
+        mockGuessDistribution: StatsGuessDistribution = StatsGuessDistribution(),
+        mockPlayAgainButton: StatsModalContent.PlayAgainButton = StatsModalContent.PlayAgainButton()
+    )
+    {
+        self.init(
+            stats: mockStats,
+            guessDistribution: mockGuessDistribution,
+            playAgainButton:  mockPlayAgainButton
+        )
+    }
+}
+
+extension StatsModalContent.PlayAgainButton
+{
+    init(mockLabel: String = "", mockTapped: @escaping () -> Void = { })
+    {
+        self.init(label: mockLabel) { mockTapped() }
+    }
+}

--- a/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentTests.swift
+++ b/iosApp/iosAppTests/feature_stats/presentation/component/StatsModalContentTests.swift
@@ -38,10 +38,10 @@ final class StatsModalContentTests: XCTestCase
         // then
         XCTAssertNoThrow(try sut.inspect().vStack())
         XCTAssertEqual(expectedWidth, try sut.inspect().vStack().fixedWidth())
-        XCTAssertEqual(expectedBoarderRadius, try sut.inspect().vStack().cornerRadius())
         XCTAssertEqual(expectedHorizontalPadding, try sut.inspect().vStack().padding(.horizontal))
         XCTAssertEqual(expectedVerticalPadding, try sut.inspect().vStack().padding(.vertical))
-        XCTAssertEqual(.ui.surface, try sut.inspect().vStack().background().color().value())
+        XCTAssertEqual(mockFrame().height * (10 / idealFrame().height), try sut.inspect().vStack().shadow().radius)
+        XCTAssertEqual(Color.black.opacity(0.25), try sut.inspect().vStack().shadow().color)
     }
     
     func test_when_view_appears__a_Text_view_matching_design_requirements_is_displayed_in_the_VStack_index_1() throws

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CachedCompletedGame.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CachedCompletedGame.kt
@@ -4,6 +4,8 @@ import com.megabreezy.breezybuilds_wordle.core.domain.model.Answer
 import com.megabreezy.breezybuilds_wordle.core.domain.model.CompletedGame
 import com.megabreezy.breezybuilds_wordle.core.domain.model.Guess
 import com.megabreezy.breezybuilds_wordle.core.domain.model.Word
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.RealmUUID
 import io.realm.kotlin.types.annotations.Index
@@ -22,13 +24,16 @@ class CachedCompletedGame(): RealmObject
     var answer: Answer = Answer(word = Word(word = this.word), isCurrent = false)
     var isCurrent = false
     var playerGuessedCorrectly = false
-    var playerGuesses: List<String> = listOf()
+    var playerGuesses: RealmList<String> = realmListOf()
 
     constructor(game: CompletedGame): this()
     {
+        val guessesList = realmListOf<String>()
+        game.playerGuesses().forEach { guessesList.add("${it.word()}") }
+
         this.answer = game.answer()
         this.date = game.date()
-        this.playerGuesses = game.playerGuesses().map { "${it.word()}" }
+        this.playerGuesses = guessesList
         this.playerGuessedCorrectly = game.answer().playerGuessedCorrectly() ?: false
         this.isCurrent = game.answer().isCurrent()
         this.word = game.answer().word().toString()

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CompletedGameLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/data/source/completed_game/CompletedGameLocalDataSource.kt
@@ -4,6 +4,7 @@ import com.megabreezy.breezybuilds_wordle.core.domain.model.CompletedGame
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
 import io.realm.kotlin.ext.query
+import io.realm.kotlin.ext.realmListOf
 
 class CompletedGameLocalDataSource(private var realm: Realm? = null): CompletedGameLocalDataManageable
 {
@@ -21,6 +22,9 @@ class CompletedGameLocalDataSource(private var realm: Realm? = null): CompletedG
 
     override suspend fun put(newCompletedGame: CompletedGame): CompletedGame
     {
+        val guessesToAdd = realmListOf<String>()
+        newCompletedGame.playerGuesses().forEach { guessesToAdd.add("${it.word()}") }
+
         realm?.write()
         {
             copyToRealm(
@@ -28,7 +32,7 @@ class CompletedGameLocalDataSource(private var realm: Realm? = null): CompletedG
                 {
                     answer = newCompletedGame.answer()
                     date = newCompletedGame.date()
-                    playerGuesses = newCompletedGame.playerGuesses().map { "${it.word()}" }
+                    playerGuesses = guessesToAdd
                     playerGuessedCorrectly = newCompletedGame.answer().playerGuessedCorrectly() ?: false
                     word = "${newCompletedGame.answer().word()}"
                 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/navigation/AppNavigationHandleable.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/navigation/AppNavigationHandleable.kt
@@ -5,6 +5,7 @@ interface AppNavigationHandleable
     fun currentRoute(): AppRoute?
     fun navigate(route: AppRoute, direction: NavigationDirection = NavigationDirection.INSTANT)
     fun popBack(numberOfScreens: Int)
+    fun setSceneNavigator(newSceneNavigator: SceneNavigationHandleable)
 }
 
 enum class NavigationDirection { FORWARD, BACKWARD, INSTANT }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/navigation/AppNavigator.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/navigation/AppNavigator.kt
@@ -20,7 +20,7 @@ class AppNavigator(
 
     fun routes() = this.routes
 
-    fun setSceneNavigator(newSceneNavigator: SceneNavigationHandleable)
+    override fun setSceneNavigator(newSceneNavigator: SceneNavigationHandleable)
     {
         sceneNavigator = newSceneNavigator
     }
@@ -61,4 +61,11 @@ class AppNavigator(
     {
         TODO("Not yet implemented")
     }
+}
+
+class NavHelper: KoinComponent
+{
+    private val appNavigator: AppNavigationHandleable by inject()
+
+    fun appNavigator() = this.appNavigator
 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/ui/app_modal/AppModal.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/core/ui/app_modal/AppModal.kt
@@ -1,5 +1,8 @@
 package com.megabreezy.breezybuilds_wordle.core.ui.app_modal
 
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
 class AppModal: AppModalRepresentable
 {
     private var content: AppModalContentRepresentable? = null
@@ -13,4 +16,11 @@ class AppModal: AppModalRepresentable
     override fun setContent(newContent: AppModalContentRepresentable?) { this.content = newContent }
 
     override fun setHandler(newHandler: AppModalViewHandleable?) { this.viewHandler = newHandler }
+}
+
+class AppModalHelper(): KoinComponent
+{
+    private val appModal: AppModalRepresentable by inject()
+
+    fun appModal() = this.appModal
 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/FinalizeActiveGameBoardRow.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/FinalizeActiveGameBoardRow.kt
@@ -2,9 +2,12 @@ package com.megabreezy.breezybuilds_wordle.feature.game.domain.use_case
 
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameKeyboard
+import org.koin.core.component.inject
 
 suspend fun GameUseCase.finalizeActiveGameBoardRow()
 {
+    val gameBoard: GameBoard by inject()
+
     var answer = getGameAnswer().word()
     val keysToCompare: (String) -> List<GameKeyboard.Key> = { word ->
         getGameKeyboard().rows().flatten().filter { word.contains("${it.letter() ?: ""}") }
@@ -18,7 +21,7 @@ suspend fun GameUseCase.finalizeActiveGameBoardRow()
 
     for (key in keysToCompare(answer))
     {
-        getGameBoard().activeRow()?.forEachIndexed()
+        gameBoard.activeRow()?.forEachIndexed()
         { index, tile ->
             if (tile.state() != GameBoard.Tile.State.HIDDEN) return
 

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/FinalizeActiveGameBoardRow.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/FinalizeActiveGameBoardRow.kt
@@ -1,18 +1,33 @@
 package com.megabreezy.breezybuilds_wordle.feature.game.domain.use_case
 
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameKeyboard
 
 suspend fun GameUseCase.finalizeActiveGameBoardRow()
 {
-    for (key in getGameKeyboard().rows().flatten())
+    var answer = getGameAnswer().word()
+    val keysToCompare: (String) -> List<GameKeyboard.Key> = { word ->
+        getGameKeyboard().rows().flatten().filter { word.contains("${it.letter() ?: ""}") }
+    }
+    val newTileState: (Char, String, Int) -> GameBoard.Tile.State = {
+        tileLetter, word, index ->
+            if (tileLetter == word[index]) GameBoard.Tile.State.CORRECT
+            else if (word.contains("$tileLetter")) GameBoard.Tile.State.CLOSE
+            else GameBoard.Tile.State.INCORRECT
+    }
+
+    for (key in keysToCompare(answer))
     {
         getGameBoard().activeRow()?.forEachIndexed()
         { index, tile ->
-            if (tile.letter() == getGameAnswer().word()[index])
-                tile.setState(newState = GameBoard.Tile.State.CORRECT)
-            else if (getGameAnswer().word().contains("${tile.letter()}"))
-                tile.setState(newState = GameBoard.Tile.State.CLOSE)
-            else tile.setState(newState = GameBoard.Tile.State.INCORRECT)
+            if (tile.state() != GameBoard.Tile.State.HIDDEN) return
+
+            tile.letter()?.let()
+            { tileLetter ->
+                tile.setState(newState = newTileState(tileLetter, answer, index))
+
+                answer = answer.replaceFirst(oldValue = "$tileLetter", newValue = "_")
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoard.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoard.kt
@@ -2,7 +2,6 @@ package com.megabreezy.breezybuilds_wordle.feature.game.domain.use_case
 
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameGuessGateway
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
-import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameKeyboard
 import org.koin.core.component.inject
 
 suspend fun GameUseCase.getGameBoard(
@@ -13,9 +12,10 @@ suspend fun GameUseCase.getGameBoard(
     val gameBoard: GameBoard by inject()
     val gameInProgress: Boolean = try { getGameAnswer(attemptCreateOnFailure = false); true } catch(_: Throwable) { false }
     val answer = GameUseCase().getGameAnswer()
-
     val gameBoardIsFull = gameBoard.rows().flatten().none { it.state() == GameBoard.Tile.State.HIDDEN } &&
             !gameBoard.rows().flatten().none { it.state() != GameBoard.Tile.State.HIDDEN }
+    val gameBoardContainsCorrectAnswer = gameBoard.rows().firstOrNull ()
+        { row -> row.all { it.state() == GameBoard.Tile.State.CORRECT } } != null
 
     if (gameBoard.rows().count() < 6)
     {
@@ -48,7 +48,7 @@ suspend fun GameUseCase.getGameBoard(
         }
     }
 
-    if (resetIfNecessary && (!gameInProgress || gameBoardIsFull)) gameBoard.reset()
+    if (resetIfNecessary && (!gameInProgress || gameBoardIsFull || gameBoardContainsCorrectAnswer)) gameBoard.reset()
 
     return gameBoard
 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoard.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoard.kt
@@ -2,6 +2,7 @@ package com.megabreezy.breezybuilds_wordle.feature.game.domain.use_case
 
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameGuessGateway
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameKeyboard
 import org.koin.core.component.inject
 
 suspend fun GameUseCase.getGameBoard(
@@ -12,6 +13,9 @@ suspend fun GameUseCase.getGameBoard(
     val gameBoard: GameBoard by inject()
     val gameInProgress: Boolean = try { getGameAnswer(attemptCreateOnFailure = false); true } catch(_: Throwable) { false }
     val answer = GameUseCase().getGameAnswer()
+
+    val gameBoardIsFull = gameBoard.rows().flatten().none { it.state() == GameBoard.Tile.State.HIDDEN } &&
+            !gameBoard.rows().flatten().none { it.state() != GameBoard.Tile.State.HIDDEN }
 
     if (gameBoard.rows().count() < 6)
     {
@@ -44,7 +48,7 @@ suspend fun GameUseCase.getGameBoard(
         }
     }
 
-    if (resetIfNecessary && !gameInProgress) gameBoard.reset()
+    if (resetIfNecessary && (!gameInProgress || gameBoardIsFull)) gameBoard.reset()
 
     return gameBoard
 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEvents.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEvents.kt
@@ -5,6 +5,7 @@ import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameAnswer
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameGuessGateway
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.SavedGameGateway
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameKeyboard
 import com.megabreezy.breezybuilds_wordle.feature.game.presentation.GameSceneHandleable
 import kotlinx.coroutines.delay
 import org.koin.core.component.inject
@@ -15,9 +16,17 @@ suspend fun GameUseCase.setUpGameEvents(
 )
 {
     val answerRepository: GameAnswerGateway by inject()
+    val gameBoard: GameBoard by inject()
     val guessRepository: GameGuessGateway by inject()
     val savedGameRepository: SavedGameGateway by inject()
     val gameNavigationHandler: GameNavigationHandleable by inject()
+    val getTileByLetters: (String?, GameKeyboard.Key) -> GameBoard.Tile? = { letters, key ->
+        gameBoard.activeRow()?.firstOrNull()
+        {
+            if (letters == null) it.letter() == null && key.letter() != null && key.letters() != "ENTER"
+            else it.letter() != null && key.letters() == letters
+        }
+    }
 
     getGameKeyboard(resetIfNecessary = true)
     getGameBoard(resetIfNecessary = true, reloadIfNecessary = true)
@@ -27,26 +36,17 @@ suspend fun GameUseCase.setUpGameEvents(
     {
         key.setOnClick()
         {
-            val tileToSet = getGameBoard().activeRow()?.firstOrNull()
-            {
-                it.letter() == null && key.letter() != null && key.letters() != "ENTER"
-            }
-            val tileToBackspace = getGameBoard().activeRow()?.lastOrNull()
-            {
-                it.letter() != null && key.letters() == "BACKSPACE"
-            }
-
-            tileToBackspace?.let()
+            getTileByLetters("BACKSPACE", key)?.let()
             { tile ->
                 tile.setLetter(newLetter = null)
                 sceneHandler?.onRevealNextTile()
             }
-            ?: tileToSet?.let()
+            ?: getTileByLetters(null, key)?.let()
             { tile ->
                 tile.setLetter(newLetter = key.letter())
                 sceneHandler?.onRevealNextTile()
             }
-            ?: if (key.letters() == "ENTER")
+            ?: getTileByLetters("ENTER", key)?.let()
             {
                 try
                 {
@@ -100,7 +100,7 @@ suspend fun GameUseCase.setUpGameEvents(
                         handler.onAnnouncementShouldHide()
                     }
                 }
-            } else Unit
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEvents.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEvents.kt
@@ -52,8 +52,8 @@ suspend fun GameUseCase.setUpGameEvents(
                 {
                     guessWord()
 
-                    answerRepository.updateAnswerGuessed(existingAnswer = getGameAnswer())
                     savedGameRepository.create()
+                    answerRepository.updateAnswerGuessed(existingAnswer = getGameAnswer())
                     guessRepository.clear()
                     getAnnouncement().setMessage(newMessage = "Correct! Thanks for playing!")
                     sceneHandler?.onGameOver()
@@ -79,8 +79,8 @@ suspend fun GameUseCase.setUpGameEvents(
                     }
                     catch (e: GameBoard.SetNewActiveRowFailedException)
                     {
-                        answerRepository.updateAnswerNotGuessed(existingAnswer = getGameAnswer())
                         savedGameRepository.create()
+                        answerRepository.updateAnswerNotGuessed(existingAnswer = getGameAnswer())
                         guessRepository.clear()
                         getAnnouncement().setMessage(newMessage = "Game Over")
                         sceneHandler?.onGameOver()

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEvents.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEvents.kt
@@ -98,7 +98,7 @@ suspend fun GameUseCase.setUpGameEvents(
                     }
                 }
             }
-            getTileByLetters("BACKSPACE", key)?.let()
+            ?: getTileByLetters("BACKSPACE", key)?.let()
             { tile ->
                 tile.setLetter(newLetter = null)
                 sceneHandler?.onRevealNextTile()

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/UpdateGameKeyboardHints.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/UpdateGameKeyboardHints.kt
@@ -1,10 +1,14 @@
 package com.megabreezy.breezybuilds_wordle.feature.game.domain.use_case
 
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameKeyboard
+import org.koin.core.component.inject
 
 suspend fun GameUseCase.updateGameKeyboardHints()
 {
-    getGameBoard().activeRow()?.forEachIndexed()
+    val gameBoard: GameBoard by inject()
+
+    gameBoard.activeRow()?.forEachIndexed()
     { index, tile ->
         for (currentKey in getGameKeyboard().rows().flatten())
         {

--- a/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/util/GameKoinModule.kt
+++ b/shared/src/commonMain/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/util/GameKoinModule.kt
@@ -1,11 +1,15 @@
 package com.megabreezy.breezybuilds_wordle.feature.game.util
 
+import com.megabreezy.breezybuilds_wordle.core.data.source.completed_game.CompletedGameLocalDataManageable
+import com.megabreezy.breezybuilds_wordle.core.data.source.completed_game.CompletedGameLocalDataSource
 import com.megabreezy.breezybuilds_wordle.feature.game.data.gateway.GameAnswerRepository
 import com.megabreezy.breezybuilds_wordle.feature.game.data.gateway.GameGuessRepository
+import com.megabreezy.breezybuilds_wordle.feature.game.data.gateway.SavedGameRepository
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.GameNavigationHandleable
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.GameNavigationHandler
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameAnswerGateway
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameGuessGateway
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.SavedGameGateway
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.Announcement
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.AnnouncementRepresentable
 import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
@@ -24,8 +28,12 @@ class GameKoinModule
 
         single<GameNavigationHandleable> { GameNavigationHandler() }
 
+        single<CompletedGameLocalDataManageable> { CompletedGameLocalDataSource() }
+
         single<GameAnswerGateway> { GameAnswerRepository() }
 
         single<GameGuessGateway> { GameGuessRepository() }
+
+        single<SavedGameGateway> { SavedGameRepository() }
     }
 }

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/GameNavigationHandlerTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/GameNavigationHandlerTests.kt
@@ -3,6 +3,7 @@ package com.megabreezy.breezybuilds_wordle.feature.game.domain
 import com.megabreezy.breezybuilds_wordle.core.navigation.AppNavigationHandleable
 import com.megabreezy.breezybuilds_wordle.core.navigation.AppRoute
 import com.megabreezy.breezybuilds_wordle.core.navigation.NavigationDirection
+import com.megabreezy.breezybuilds_wordle.core.navigation.SceneNavigationHandleable
 import com.megabreezy.breezybuilds_wordle.feature.game.util.GameKoinModule
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -78,5 +79,6 @@ class GameNavigationHandlerTests
 
         override fun currentRoute(): AppRoute? = null
         override fun popBack(numberOfScreens: Int) { }
+        override fun setSceneNavigator(newSceneNavigator: SceneNavigationHandleable) { }
     }
 }

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/FinalizeActiveGameBoardRowTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/FinalizeActiveGameBoardRowTests.kt
@@ -1,0 +1,78 @@
+package com.megabreezy.breezybuilds_wordle.feature.game.domain.use_case
+
+import com.megabreezy.breezybuilds_wordle.core.util.CoreKoinModule
+import com.megabreezy.breezybuilds_wordle.feature.game.data.gateway.mock.GameAnswerRepositoryCommonMock
+import com.megabreezy.breezybuilds_wordle.feature.game.data.gateway.mock.GameGuessRepositoryCommonMock
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameAnswerGateway
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.gateway.GameGuessGateway
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameAnswer
+import com.megabreezy.breezybuilds_wordle.feature.game.domain.model.GameBoard
+import com.megabreezy.breezybuilds_wordle.feature.game.util.GameKoinModule
+import kotlinx.coroutines.runBlocking
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FinalizeActiveGameBoardRowTests
+{
+    private lateinit var answerRepository: GameAnswerRepositoryCommonMock
+    private lateinit var guessRepository: GameGuessRepositoryCommonMock
+
+    @BeforeTest
+    fun setUp()
+    {
+        answerRepository = GameAnswerRepositoryCommonMock()
+        guessRepository = GameGuessRepositoryCommonMock()
+
+        startKoin()
+        {
+            modules(
+                CoreKoinModule().mockModule(),
+                GameKoinModule().module(),
+                module()
+                {
+                    single<GameAnswerGateway> { answerRepository }
+                    single<GameGuessGateway> { guessRepository }
+                }
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() = stopKoin()
+
+    @Test
+    fun `When use case invoked an active row contains REFER and answer is REVUE - GameBoard row matches expected updated state`()
+    {
+        // given
+        answerRepository.getShouldFail = true
+        answerRepository.createdGameAnswer = GameAnswer(word = "REVUE")
+
+        val gameBoard = runBlocking { GameUseCase().getGameBoard() }
+        gameBoard.setRows(newRows = listOf(
+            listOf(
+                GameBoard.Tile(letter = 'R'), GameBoard.Tile(letter = 'E'),
+                GameBoard.Tile(letter = 'F'), GameBoard.Tile(letter = 'E'), GameBoard.Tile(letter = 'R')
+            ),
+            listOf(), listOf(), listOf(), listOf(), listOf()
+        ))
+        val expectedRow = listOf(
+            GameBoard.Tile(letter = 'R', state = GameBoard.Tile.State.CORRECT),
+            GameBoard.Tile(letter = 'E', state = GameBoard.Tile.State.CORRECT),
+            GameBoard.Tile(letter = 'F', state = GameBoard.Tile.State.INCORRECT),
+            GameBoard.Tile(letter = 'E', state = GameBoard.Tile.State.CLOSE),
+            GameBoard.Tile(letter = 'R', state = GameBoard.Tile.State.INCORRECT)
+        )
+
+        // when
+        runBlocking { GameUseCase().finalizeActiveGameBoardRow() }
+
+        // then
+        gameBoard.rows().first().forEach { println("${it.letter()} : ${it.state()}") }
+        assertEquals(expectedRow, gameBoard.rows().first())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoardTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoardTests.kt
@@ -162,4 +162,50 @@ class GetGameBoardTests: KoinComponent
             }
         }
     }
+
+    @Test
+    fun `When use case invoked resetIfNecessary set true and all gameBoard row tiles are unhidden - GameBoard is reset`()
+    {
+        // given
+        val expectedGameboardRow = listOf(
+            GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile()
+        )
+        val filledGameboardRow = listOf(
+            GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.INCORRECT),
+            GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.INCORRECT),
+            GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.INCORRECT),
+            GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.INCORRECT),
+            GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.INCORRECT)
+        )
+        val answer = Answer(word = Word("SLAPS"))
+        answerLocalDataSource.getCurrentAnswerToReturn = answer
+        guessRepository.getAllGuessesToReturn = listOf()
+        val gameBoard: GameBoard by inject()
+        gameBoard.setRows(
+            newRows = listOf(
+                filledGameboardRow, filledGameboardRow, filledGameboardRow,
+                filledGameboardRow, filledGameboardRow, filledGameboardRow
+            )
+        )
+
+        // when
+        runBlocking { GameUseCase().getGameBoard(resetIfNecessary = true) }
+
+        // then
+        gameBoard.rows().forEachIndexed()
+        { index, row ->
+            assertEquals(expectedGameboardRow, gameBoard.rows()[index])
+        }
+    }
+
+    @Test
+    fun `When use case invoked resetIfNecessary set true and one gameboard row is correct - GameBoard is reset`()
+    {
+        // given
+
+        // when
+
+        // then
+        assertTrue(false)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoardTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/GetGameBoardTests.kt
@@ -193,7 +193,7 @@ class GetGameBoardTests: KoinComponent
 
         // then
         gameBoard.rows().forEachIndexed()
-        { index, row ->
+        { index, _ ->
             assertEquals(expectedGameboardRow, gameBoard.rows()[index])
         }
     }
@@ -202,10 +202,33 @@ class GetGameBoardTests: KoinComponent
     fun `When use case invoked resetIfNecessary set true and one gameboard row is correct - GameBoard is reset`()
     {
         // given
+        val expectedGameBoardRow = listOf(
+            GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile()
+        )
+        answerLocalDataSource.getCurrentAnswerToReturn = Answer(word = Word("SLAPS"))
+        guessRepository.getAllGuessesToReturn = listOf()
+        val gameBoard: GameBoard by inject()
+        gameBoard.setRows(
+            newRows = listOf(
+                listOf(
+                    GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.CORRECT),
+                    GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.CORRECT),
+                    GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.CORRECT),
+                    GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.CORRECT),
+                    GameBoard.Tile(letter = 'B', state = GameBoard.Tile.State.CORRECT)
+                ),
+                expectedGameBoardRow, expectedGameBoardRow,
+                expectedGameBoardRow, expectedGameBoardRow, expectedGameBoardRow
+            )
+        )
 
         // when
+        runBlocking { GameUseCase().getGameBoard(resetIfNecessary = true) }
 
         // then
-        assertTrue(false)
+        gameBoard.rows().forEachIndexed()
+        { index, _ ->
+            assertEquals(expectedGameBoardRow, gameBoard.rows()[index])
+        }
     }
 }

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEventsTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEventsTests.kt
@@ -536,6 +536,29 @@ class SetUpGameEventsTests: KoinComponent
     }
 
     @Test
+    fun `when use case invoked and enter Key is clicked and GameGuess is correct - the FinalizeActiveGameBoardRow use case is invoked`()
+    {
+        // given
+        val gameBoard: GameBoard by inject()
+        answerRepository.guessMatchesAnswer = true
+        runBlocking { GameUseCase().setUpGameEvents(sceneHandler = sceneHandler, announcementDelay = 0L) }
+        val keysInUse = answerRepository.createdGameAnswer!!.word().indices.map()
+        {
+            getKey(letters = "${answerRepository.createdGameAnswer!!.word()[it]}" )
+        }
+
+        // when
+        for (key in keysInUse) runBlocking { key?.click() }
+        runBlocking { getKey(letters = "ENTER")?.click() }
+
+        // then
+        gameBoard.rows().first().forEach()
+        {
+            assertEquals(GameBoard.Tile.State.CORRECT, it.state())
+        }
+    }
+
+    @Test
     fun `when use case invoked and enter Key is clicked and GameGuess is correct - injected CompletedGameGateway's put method is invoked`()
     {
         // given

--- a/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEventsTests.kt
+++ b/shared/src/commonTest/kotlin/com/megabreezy/breezybuilds_wordle/feature/game/domain/use_case/SetUpGameEventsTests.kt
@@ -169,14 +169,20 @@ class SetUpGameEventsTests: KoinComponent
         {
             GameUseCase().setUpGameEvents(sceneHandler = sceneHandler, announcementDelay = 0L)
             getKey(letters = "C")?.click()
+            getKey(letters = "C")?.click()
+            getKey(letters = "C")?.click()
         }
+        val expectedActiveGameboardRow = listOf(
+            GameBoard.Tile(letter = 'C', state = GameBoard.Tile.State.HIDDEN), GameBoard.Tile(letter = 'C', state = GameBoard.Tile.State.HIDDEN),
+            GameBoard.Tile(), GameBoard.Tile(), GameBoard.Tile()
+        )
         sceneHandler.onRevealNextTileDidInvoke = false
 
         // when
         runBlocking { getKey(letters = "BACKSPACE")?.click() }
 
         // then
-        assertNull(gameBoard.activeRow()?.firstOrNull { tile -> tile.letter() != null })
+        assertEquals(expectedActiveGameboardRow, gameBoard.activeRow())
         assertTrue(sceneHandler.onRevealNextTileDidInvoke)
     }
 


### PR DESCRIPTION
**Summary of Changes**
- Completed a basic implementation of the Stats feature for iOS!
- Following each game, the stats modal will pop up with stats representative of the player's saved completed games.
- The stats modal contains a prompt that will allow the user to launch a new game following completion of a current game.

**Code Review:**
- [ ] QA Kickoff notes added to JIRA issue
- [x] Unit tests exist if required
- [x] Code formatting standards reviewed
- [x] Error handling implemented (exceptions caught and relevant error messages displayed)

**Merge**
- [x] PR is against the correct branch
- [x] All tests pass
